### PR TITLE
セッション開始手順に出力フォーマットを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,13 @@
-## セッション開始手順
+## セッション開始（最優先・必須）
 
-1. `tasks/lessons.md` をレビューする
+最初の返答の前に必ず `tasks/lessons.md` を開いて読み、
+以下の形式で出力してから作業を開始すること。
+
+### Lessons Summary (max 5 bullets)
+- ...
+
+### Apply to this session
+- ...
 
 ---
 


### PR DESCRIPTION
# 概要

CLAUDE.md の「セッション開始手順」セクションを強化し、セッション開始時の出力フォーマットを明記する。

## 種別

- [x] docs

---

# 変更内容（What）

- 見出しを「セッション開始手順」→「セッション開始（最優先・必須）」に変更
- `tasks/lessons.md` を読んだ後に出力すべきフォーマット（Lessons Summary / Apply to this session）を追加

---

# 変更理由（Why）

- 従来は「レビューする」のみで曖昧だったため、具体的な出力形式を定義してセッション開始時の実行品質を安定させる

---

# 影響範囲（Impact）

- Frontend: なし
- Backend: なし
- Infra: なし
- Database: なし
- External API: なし

---

# 動作確認

## 確認観点

- [x] 正常系
- [ ] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. 新しいセッションを開始する
2. `tasks/lessons.md` が読み込まれ、Lessons Summary / Apply to this session の形式で出力されることを確認

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] E2Eテスト追加／更新
- [ ] 既存テスト通過

※ ドキュメント変更のみのためテスト対象外

---

# リスク・懸念点

- なし

---

# 関連 Issue

Closes #33

---

# チェックリスト（レビュー前セルフチェック）

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み