### PR TITLE
chore: Dependabot を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/packages/api"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
# 概要

依存パッケージの自動更新のため Dependabot を導入。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [x] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `.github/dependabot.yml` を新規作成
- npm（`packages/api/`）と GitHub Actions の依存を weekly で監視
- コミットメッセージに `chore(deps)` プレフィックスを付与

---

# 変更理由（Why）

- 依存パッケージのセキュリティアップデートやバージョン更新を自動化するため

---

# 影響範囲（Impact）

- Backend: なし
- Infra: Dependabot が weekly で PR を自動作成するようになる

---

# 動作確認

## 確認観点

- [x] 正常系
- [ ] 異常系
- [ ] 境界値
- [ ] 回帰影響なし

## 確認手順

1. マージ後、Dependabot が有効化されていることを Settings > Code security で確認

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [ ] 既存テスト通過

---

# リスク・懸念点

- なし

---

# 関連 Issue

Closes #43

---

# チェックリスト（レビュー前セルフチェック）

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み