### PR TITLE
chore: Volta による Node.js バージョン固定を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "docai-expense-parser",
   "private": true,
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "build": "npm run build --workspace=@docai/api",
     "lint": "npm run lint --workspace=@docai/api",
@@ -12,5 +14,8 @@
     "test:unit": "npm run test:unit --workspace=@docai/api",
     "test:integration": "npm run test:integration --workspace=@docai/api",
     "test:watch": "npm run test:watch --workspace=@docai/api"
+  },
+  "volta": {
+    "node": "20.20.1"
   }
 }


### PR DESCRIPTION
## Summary
- `package.json` に `volta` フィールドを追加し、Node.js v20.20.1 をプロジェクトに固定
- Volta ユーザーはこのリポジトリに入ると自動で Node.js 20 が使用される

## Test plan
- [ ] Volta がインストールされた環境で `node -v` が `v20.20.1` になることを確認
- [ ] CI（Node.js 20）が正常にパスすることを確認

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)