### PR TITLE
chore: テストカバレッジの閾値を設定

### DIFF
--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
+      thresholds: {
+        statements: 60,
+        branches: 70,
+        functions: 70,
+        lines: 60,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- `vitest.config.ts` にカバレッジ閾値を追加
- statements: 60%, branches: 70%, functions: 70%, lines: 60%
- 現状のカバレッジ（statements: 68%, branches: 77%, functions: 80%, lines: 67%）を十分に上回る値で設定
- `src/index.ts` のテスト充実後に閾値を引き上げ予定

## Test plan
- [ ] `npm run test:coverage` が閾値をパスすること（ローカル確認済み）
- [ ] CI 上でもカバレッジチェックが正常に動作すること

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)