### PR TITLE
chore: .gitignore に coverage ディレクトリを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .claude/settings.local.json
 node_modules
 dist
+coverage
 tasks
 secrets
 input


### PR DESCRIPTION
# 概要

`.gitignore` に `coverage` ディレクトリを追加し、カバレッジ計測の生成物がリポジトリに含まれないようにする。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [x] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `.gitignore` に `coverage` を追加

---

# 変更理由（Why）

- #55 でカバレッジ計測を導入した際、生成物（`packages/api/coverage/`）の除外設定が漏れていた

---

# 影響範囲（Impact）

- Backend: なし
- Infra: `.gitignore` のみ

---

# 動作確認

## 確認観点

- [x] 正常系
- [ ] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. `npm run test:coverage` を実行
2. `git status` で `coverage/` が表示されないことを確認

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過

---

# リスク・懸念点

- なし

---

# 関連 Issue

Closes #70

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある
- [x] ファイル I/O に適切なエラーハンドリングがある

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない