### PR TITLE
docs: デプロイ手順をコンテナ内実行に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,21 +207,9 @@ npm run shell -w @docai/functions
 parseDocument({method: "POST", body: {content: "base64data", mimeType: "application/pdf"}})
 ```
 
-### Functions をデプロイする
+### デプロイ
 
-Firebase CLI を使用して GCP にデプロイします。
-
-```bash
-# 1. Firebase にログイン（初回のみ）
-firebase login
-# ブラウザが開けない環境では: firebase login --no-localhost
-
-# 2. Firebase プロジェクトを設定
-firebase use <project-id>
-
-# 3. デプロイ（--project で対象プロジェクトを明示）
-firebase deploy --only functions --project <project-id>
-```
+デプロイはそれぞれのパッケージの Docker コンテナ内から実行します。
 
 デプロイ前に以下の準備が必要です：
 
@@ -229,13 +217,23 @@ firebase deploy --only functions --project <project-id>
 - **GCP 側**: Document AI API の有効化、プロセッサの作成
 - **ローカル**: `packages/functions/.env.<project-id>` に環境変数を設定（`GCP_PROJECT_ID`, `DOCAI_LOCATION`, `DOCAI_PROCESSOR_ID`）
 
-### Web フロントエンドをデプロイする
-
-Firebase Hosting を使用して Web フロントエンドをデプロイします。
-`predeploy` で `npm run docker:web:build` を実行するため、Docker が起動している必要があります。
+#### Functions
 
 ```bash
-# Hosting のみデプロイ（predeploy で自動ビルドされます）
+npm run docker:functions:sh
+
+# コンテナ内で
+firebase login --no-localhost  # 初回のみ
+firebase deploy --only functions --project <project-id>
+```
+
+#### Web（Hosting）
+
+```bash
+npm run docker:web:sh
+
+# コンテナ内で
+firebase login --no-localhost  # 初回のみ
 firebase deploy --only hosting --project <project-id>
 ```
 


### PR DESCRIPTION
# 概要

README のデプロイ手順を、各パッケージの Docker コンテナ内から実行する形式に統一する。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [ ] chore
- [x] docs
- [ ] test

---

# 変更内容（What）

- Functions と Web のデプロイ手順を「デプロイ」セクションに統合
- `docker:functions:sh` / `docker:web:sh` でコンテナに入ってから `firebase deploy` を実行する手順に変更
- `firebase login --no-localhost` をデフォルトの認証方法として記載

# 変更理由（Why）

- 実際の運用では Functions・Web ともにコンテナ内からデプロイを行っている
- README がこの運用に合っていなかった

# 影響範囲（Impact）

- Backend: なし
- Infra: なし

---

# 動作確認

## 確認観点

- [x] 正常系
- [ ] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. README の記述が正確であることを確認

---

# テスト

ドキュメントのみの変更。

---

# リスク・懸念点

- なし

# 関連 Issue

なし

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 影響範囲を確認済み

### 変更範囲

- [x] PR が1つの目的に絞られている