### PR TITLE
feat(functions): onCall / onRequest 分離と API キー認証を追加

### DIFF
--- a/packages/functions/.env.example
+++ b/packages/functions/.env.example
@@ -1,3 +1,6 @@
 GCP_PROJECT_ID=your-gcp-project-id
 DOCAI_LOCATION=us
 DOCAI_PROCESSOR_ID=your-processor-id
+
+# ローカル開発用（.env.local に設定）。デプロイ環境では Secret Manager で管理
+# API_KEY=your-api-key

--- a/packages/functions/src/handlers/parse-document-call.test.ts
+++ b/packages/functions/src/handlers/parse-document-call.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { handleParseDocumentCall } from "./parse-document-call.js";
+
+vi.mock("../infrastructure/config.js", () => ({
+  loadFunctionsConfig: () => ({
+    projectId: "test-project",
+    location: "us",
+    processorId: "proc-123",
+  }),
+}));
+
+const mockProcess = vi.fn();
+vi.mock("../infrastructure/document-ai-client.js", () => ({
+  createDocumentProcessor: () => ({ process: mockProcess }),
+}));
+
+function createMockRequest(overrides: Partial<{ data: unknown; auth: unknown }> = {}) {
+  return {
+    data: { content: "base64data", mimeType: "application/pdf" },
+    ...overrides,
+  } as Parameters<typeof handleParseDocumentCall>[0];
+}
+
+describe("handleParseDocumentCall", () => {
+  beforeEach(() => {
+    mockProcess.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("正常なリクエストでentitiesを返す", async () => {
+    const mockEntities = [{ type: "total_amount", mentionText: "1,234", confidence: 0.95 }];
+    mockProcess.mockResolvedValue(mockEntities);
+
+    const result = await handleParseDocumentCall(createMockRequest());
+
+    expect(result).toEqual({ entities: mockEntities });
+  });
+
+  it("バリデーションエラーで HttpsError を投げる", async () => {
+    const request = createMockRequest({ data: {} });
+
+    await expect(handleParseDocumentCall(request)).rejects.toThrow(
+      "content は必須で、空でない文字列（base64）である必要があります",
+    );
+  });
+
+  it("Document AI処理エラーで HttpsError を投げる", async () => {
+    mockProcess.mockRejectedValue(new Error("API error"));
+
+    await expect(handleParseDocumentCall(createMockRequest())).rejects.toThrow(
+      "内部サーバーエラー",
+    );
+  });
+});

--- a/packages/functions/src/handlers/parse-document-call.ts
+++ b/packages/functions/src/handlers/parse-document-call.ts
@@ -1,0 +1,36 @@
+import { HttpsError, type CallableRequest } from "firebase-functions/v2/https";
+import { validateParseDocumentRequest } from "../infrastructure/request-validator.js";
+import { loadFunctionsConfig } from "../infrastructure/config.js";
+import { createDocumentProcessor } from "../infrastructure/document-ai-client.js";
+import { parseDocument, type DocumentEntity } from "../application/parse-document.js";
+
+export const handleParseDocumentCall = async (
+  request: CallableRequest,
+): Promise<{ entities: DocumentEntity[] }> => {
+  const validation = validateParseDocumentRequest(request.data);
+  if (!validation.ok) {
+    throw new HttpsError("invalid-argument", validation.message);
+  }
+
+  try {
+    const config = loadFunctionsConfig();
+    const processor = createDocumentProcessor(config.location);
+
+    const entities = await parseDocument(
+      {
+        projectId: config.projectId,
+        location: config.location,
+        processorId: config.processorId,
+        content: validation.data.content,
+        mimeType: validation.data.mimeType,
+      },
+      processor,
+    );
+
+    return { entities };
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error("parseDocument 失敗:", message);
+    throw new HttpsError("internal", "内部サーバーエラー");
+  }
+};

--- a/packages/functions/src/handlers/parse-document.test.ts
+++ b/packages/functions/src/handlers/parse-document.test.ts
@@ -17,12 +17,19 @@ vi.mock("../infrastructure/document-ai-client.js", () => ({
 type HandlerParams = Parameters<typeof handleParseDocument>;
 
 function createMockReqRes(
-  overrides: Partial<{ method: string; body: unknown; path: string }> = {},
+  overrides: Partial<{
+    method: string;
+    body: unknown;
+    path: string;
+    headers: Record<string, string>;
+  }> = {},
 ) {
+  const { headers = {}, ...rest } = overrides;
   const req = {
     method: "POST",
     body: { content: "base64data", mimeType: "application/pdf" },
-    ...overrides,
+    headers,
+    ...rest,
   } as unknown as HandlerParams[0];
 
   const res = {
@@ -33,13 +40,17 @@ function createMockReqRes(
   return { req, res };
 }
 
+const TEST_API_KEY = "test-api-key-12345";
+
 describe("handleParseDocument", () => {
   beforeEach(() => {
     mockProcess.mockReset();
+    vi.stubEnv("API_KEY", TEST_API_KEY);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("POST以外のメソッドは405を返す", async () => {
@@ -52,8 +63,29 @@ describe("handleParseDocument", () => {
     });
   });
 
+  it("Authorizationヘッダーなしは401を返す", async () => {
+    const { req, res } = createMockReqRes();
+    await handleParseDocument(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "認証が必要です。" });
+  });
+
+  it("不正なAPIキーは401を返す", async () => {
+    const { req, res } = createMockReqRes({
+      headers: { authorization: "Bearer wrong-key" },
+    });
+    await handleParseDocument(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "無効な API キーです。" });
+  });
+
   it("バリデーションエラーは400を返す", async () => {
-    const { req, res } = createMockReqRes({ body: {} });
+    const { req, res } = createMockReqRes({
+      body: {},
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
     await handleParseDocument(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
@@ -63,7 +95,9 @@ describe("handleParseDocument", () => {
     const mockEntities = [{ type: "total_amount", mentionText: "1,234", confidence: 0.95 }];
     mockProcess.mockResolvedValue(mockEntities);
 
-    const { req, res } = createMockReqRes();
+    const { req, res } = createMockReqRes({
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
     await handleParseDocument(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
@@ -73,7 +107,9 @@ describe("handleParseDocument", () => {
   it("Document AI処理エラー時は500を返す", async () => {
     mockProcess.mockRejectedValue(new Error("API error"));
 
-    const { req, res } = createMockReqRes();
+    const { req, res } = createMockReqRes({
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
     await handleParseDocument(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);

--- a/packages/functions/src/handlers/parse-document.ts
+++ b/packages/functions/src/handlers/parse-document.ts
@@ -1,4 +1,5 @@
 import type { Request } from "firebase-functions/v2/https";
+import { validateApiKey } from "../infrastructure/auth-validator.js";
 import { validateParseDocumentRequest } from "../infrastructure/request-validator.js";
 import { loadFunctionsConfig } from "../infrastructure/config.js";
 import { createDocumentProcessor } from "../infrastructure/document-ai-client.js";
@@ -16,6 +17,14 @@ export const handleParseDocument = async (req: Request, res: JsonResponse): Prom
     const body = { error: "許可されていないメソッドです。POST を使用してください。" };
     console.log(`[RES] 405`, JSON.stringify(body));
     res.status(405).json(body);
+    return;
+  }
+
+  const authResult = validateApiKey(req.headers.authorization, process.env.API_KEY ?? "");
+  if (!authResult.ok) {
+    const body = { error: authResult.message };
+    console.log(`[RES] 401`, JSON.stringify(body));
+    res.status(401).json(body);
     return;
   }
 

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -1,4 +1,15 @@
-import { onRequest } from "firebase-functions/v2/https";
+import { onCall, onRequest } from "firebase-functions/v2/https";
+import { defineSecret } from "firebase-functions/params";
+import { handleParseDocumentCall } from "./handlers/parse-document-call.js";
 import { handleParseDocument } from "./handlers/parse-document.js";
 
-export const parseDocument = onRequest({ region: "asia-northeast1" }, handleParseDocument);
+const apiKey = defineSecret("API_KEY");
+
+/** Hosting（Web）用 — onCall */
+export const parseDocumentCall = onCall({ region: "asia-northeast1" }, handleParseDocumentCall);
+
+/** 外部サービス用 — onRequest + API キー認証 */
+export const parseDocumentHttp = onRequest(
+  { region: "asia-northeast1", secrets: [apiKey] },
+  handleParseDocument,
+);

--- a/packages/functions/src/infrastructure/auth-validator.test.ts
+++ b/packages/functions/src/infrastructure/auth-validator.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { validateApiKey } from "./auth-validator.js";
+
+describe("validateApiKey", () => {
+  const validKey = "test-api-key-12345";
+
+  it("正しい API キーで認証成功", () => {
+    const result = validateApiKey(`Bearer ${validKey}`, validKey);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("不正な API キーで認証失敗", () => {
+    const result = validateApiKey("Bearer wrong-key", validKey);
+    expect(result).toEqual({ ok: false, message: "無効な API キーです。" });
+  });
+
+  it("Bearer 以外の形式で認証失敗", () => {
+    const result = validateApiKey("Basic abc123", validKey);
+    expect(result).toEqual({
+      ok: false,
+      message: "Authorization ヘッダーの形式が不正です。Bearer <API_KEY> を使用してください。",
+    });
+  });
+
+  it("Authorization ヘッダーなしで認証失敗", () => {
+    const result = validateApiKey(undefined, validKey);
+    expect(result).toEqual({ ok: false, message: "認証が必要です。" });
+  });
+
+  it("Bearer の後が空で認証失敗", () => {
+    const result = validateApiKey("Bearer ", validKey);
+    expect(result).toEqual({ ok: false, message: "無効な API キーです。" });
+  });
+});

--- a/packages/functions/src/infrastructure/auth-validator.ts
+++ b/packages/functions/src/infrastructure/auth-validator.ts
@@ -1,0 +1,32 @@
+export interface AuthSuccess {
+  ok: true;
+}
+
+export interface AuthError {
+  ok: false;
+  message: string;
+}
+
+export function validateApiKey(
+  authorizationHeader: string | undefined,
+  validApiKey: string,
+): AuthSuccess | AuthError {
+  if (!authorizationHeader) {
+    return { ok: false, message: "認証が必要です。" };
+  }
+
+  if (!authorizationHeader.startsWith("Bearer ")) {
+    return {
+      ok: false,
+      message: "Authorization ヘッダーの形式が不正です。Bearer <API_KEY> を使用してください。",
+    };
+  }
+
+  const provided = authorizationHeader.slice("Bearer ".length);
+
+  if (provided !== validApiKey) {
+    return { ok: false, message: "無効な API キーです。" };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
# 概要

parseDocument の認証機構を追加。Hosting（Web）用に onCall、外部サービス用に onRequest + API キー認証でエンドポイントを分離。

## 種別

- [ ] bug
- [x] feature
- [ ] refactor
- [ ] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `parseDocumentCall`（onCall）: Hosting（Web フロントエンド）用エンドポイントを新規追加
- `parseDocumentHttp`（onRequest）: 外部サービス用エンドポイントに API キー認証（`Authorization: Bearer <key>`）を追加
- `auth-validator.ts`: API キー検証ロジックを infrastructure 層に追加（discriminated union パターン）
- `index.ts`: `defineSecret("API_KEY")` で Secret Manager から API キーを取得
- ビジネスロジック（application 層）は共通で共有

# 変更理由（Why）

- 現在 parseDocument は認証なしで公開されており、URL を知っていれば誰でもアクセス可能
- Hosting（Web）と外部サービス（GCP 外のサーバーサイド）のアクセス元が異なるため、入り口を分離して適切な認証を適用する
- 外部サービスは GCP 外のため `invoker: "private"` + OIDC 方式は不適

# 影響範囲（Impact）

- Backend: 既存の `parseDocument` エクスポートが `parseDocumentCall` + `parseDocumentHttp` に変更される（破壊的変更）
- Infra: デプロイ時に旧 Cloud Function `parseDocument` が削除され、新しい2関数が作成される。Secret Manager に `API_KEY` の事前設定が必要

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [x] 境界値
- [x] 回帰影響なし

## 確認手順

1. `npm run docker:functions:test` で全33テストが通過することを確認
2. `npm run docker:functions:lint` で lint エラーがないことを確認
3. `npm run docker:functions:test:coverage` でカバレッジ基準を満たすことを確認

---

# テスト

- [x] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過

追加テスト:
- `auth-validator.test.ts`: API キー検証の5ケース（正常/不正/形式不正/ヘッダーなし/空キー）
- `parse-document-call.test.ts`: onCall ハンドラーの3ケース（正常/バリデーションエラー/処理エラー）
- `parse-document.test.ts`: API キー認証の2ケース追加（ヘッダーなし401/不正キー401）+ 既存テストにヘッダー追加

---

# リスク・懸念点

- 既存の `parseDocument` が削除されるため、デプロイ前に Web フロントエンド側の対応（`fetch` → `httpsCallable` への変更、firebase.json リライト更新）が必要。Web 側は別タスクで対応予定
- デプロイ前に Secret Manager への `API_KEY` 登録が必要

# 関連 Issue

Closes #148

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある
- [x] ファイル I/O に適切なエラーハンドリングがある

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ドキュメント解析を呼び出し可能なエンドポイントで利用可能に（既存のHTTP版はAPIキー必須のまま併存）

* **Security**
  * APIキー認証を導入し、認証エラー時に適切な応答を返すよう強化

* **Tests**
  * 解析処理と認証ロジックをカバーするテスト群を追加・拡充

* **Docs / Dev**
  * ローカル開発向けにAPIキーの設定例を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->