### PR TITLE
fix(web): エミュレータ接続の判定を VITE_USE_EMULATOR に変更

### DIFF
--- a/docs/adr/0004-web-frontend.md
+++ b/docs/adr/0004-web-frontend.md
@@ -31,7 +31,7 @@
 
 - `src/api/firebase.ts`: Firebase App + Functions の初期化（環境変数 `VITE_FIREBASE_*` を使用）
 - `src/api/parse-document.ts`: `httpsCallable` で Functions（onCall）を呼び出し
-- 開発時は `connectFunctionsEmulator` でローカルエミュレータに自動接続（Vite の `DEV` モードで判定）
+- ローカル開発時は `connectFunctionsEmulator` でエミュレータに接続（`VITE_USE_EMULATOR` 環境変数で制御、docker-compose でのみ設定）
 - 環境変数は Vite の `.env.{mode}` ファイルで環境ごとに管理（`.env.development` / `.env.staging` / `.env.production`）
 
 ## 理由

--- a/firebase.json
+++ b/firebase.json
@@ -13,7 +13,7 @@
         "destination": "/index.html"
       }
     ],
-    "predeploy": "npm run build -w @docai/web"
+    "predeploy": "npm run build -w @docai/web -- --mode ${VITE_MODE:-production}"
   },
   "emulators": {
     "functions": {

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -85,11 +85,19 @@ CI では Storybook ビルド → Playwright テストが自動実行され、�
 
 ## デプロイ
 
+`firebase deploy` の `predeploy` フックで `npm run build` が自動実行されます。デフォルトでは mode=production でビルドされるため、開発・ステージング環境にデプロイする場合は事前に対象モードでビルドしてください。
+
 ```bash
 npm run docker:web:sh
 
 # コンテナ内で
 firebase login --no-localhost  # 初回のみ
+
+# 本番環境（デフォルト: mode=production）
+firebase deploy --only hosting --project <project-id>
+
+# 開発・ステージング環境の場合は、先にモードを指定してビルド
+npm run build -w @docai/web -- --mode development  # or staging
 firebase deploy --only hosting --project <project-id>
 ```
 
@@ -100,13 +108,13 @@ Functions の呼び出しは Firebase SDK の `httpsCallable` で直接行うた
 
 Vite の [env ファイル読み込み規約](https://vite.dev/guide/env-and-mode) に従い、モードに応じたファイルが自動ロードされます。
 
-| ファイル           | 用途                                     | 読み込みタイミング                 |
-| ------------------ | ---------------------------------------- | ---------------------------------- |
-| `.env`             | 全モード共通（`VITE_APP_PASSWORD` など） | 常時                               |
-| `.env.development` | 開発環境の Firebase 設定                 | `npm run dev`（mode=development）  |
-| `.env.staging`     | ステージング環境の Firebase 設定         | `npm run build -- --mode staging`  |
-| `.env.production`  | 本番環境の Firebase 設定                 | `npm run build`（mode=production） |
-| `.env.example`     | 設定項目のリファレンス（git 管理）       | —                                  |
+| ファイル           | 用途                                            | 読み込みタイミング                                    |
+| ------------------ | ----------------------------------------------- | ----------------------------------------------------- |
+| `.env`             | 全モード共通の設定                              | 常時                                                  |
+| `.env.development` | 開発環境（Firebase 設定・パスワード等）         | `npm run dev` / `npm run build -- --mode development` |
+| `.env.staging`     | ステージング環境（Firebase 設定・パスワード等） | `npm run build -- --mode staging`                     |
+| `.env.production`  | 本番環境（Firebase 設定・パスワード等）         | `npm run build`（mode=production）                    |
+| `.env.example`     | 設定項目のリファレンス（git 管理）              | —                                                     |
 
 ### 必要な環境変数
 
@@ -122,6 +130,13 @@ Vite の [env ファイル読み込み規約](https://vite.dev/guide/env-and-mod
 | `VITE_FIREBASE_APP_ID`              | Yes  | Firebase App ID                                 |
 | `VITE_APP_PASSWORD`                 | No   | UI アクセス制限用パスワード（未設定でスキップ） |
 
-### 開発時の Functions 接続
+### Functions エミュレータ接続
 
-`import.meta.env.DEV`（Vite の development モード）が `true` の場合、`connectFunctionsEmulator` により `localhost:8080` の Functions エミュレータに自動接続します。本番ビルドではエミュレータ接続は無効になり、Firebase プロジェクトの Functions に直接リクエストします。
+エミュレータ接続は環境変数 `VITE_USE_EMULATOR` で制御します。この変数は `.env` ファイルには設定せず、`docker-compose.yml` の `environment` でローカル開発時のみ注入されます。
+
+| シナリオ                                 | `VITE_USE_EMULATOR`        | エミュレータ |
+| ---------------------------------------- | -------------------------- | ------------ |
+| ローカル開発（`docker:web:dev`）         | `"true"`（docker-compose） | 接続する     |
+| 開発環境デプロイ（`--mode development`） | 未設定                     | 接続しない   |
+| STG 環境デプロイ（`--mode staging`）     | 未設定                     | 接続しない   |
+| 本番デプロイ（`--mode production`）      | 未設定                     | 接続しない   |

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -85,7 +85,7 @@ CI では Storybook ビルド → Playwright テストが自動実行され、�
 
 ## デプロイ
 
-`firebase deploy` の `predeploy` フックで `npm run build` が自動実行されます。デフォルトでは mode=production でビルドされるため、開発・ステージング環境にデプロイする場合は事前に対象モードでビルドしてください。
+`firebase deploy` の `predeploy` フックで自動ビルドされます。環境変数 `VITE_MODE` でビルドモードを指定できます（デフォルト: production）。
 
 ```bash
 npm run docker:web:sh
@@ -96,9 +96,11 @@ firebase login --no-localhost  # 初回のみ
 # 本番環境（デフォルト: mode=production）
 firebase deploy --only hosting --project <project-id>
 
-# 開発・ステージング環境の場合は、先にモードを指定してビルド
-npm run build -w @docai/web -- --mode development  # or staging
-firebase deploy --only hosting --project <project-id>
+# 開発環境
+VITE_MODE=development firebase deploy --only hosting --project <project-id>
+
+# ステージング環境
+VITE_MODE=staging firebase deploy --only hosting --project <project-id>
 ```
 
 デプロイ後、`https://<project-id>.web.app` で Web フロントエンドにアクセスできます。

--- a/packages/web/docker/docker-compose.yml
+++ b/packages/web/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     env_file: ../.env
     environment:
       API_PROXY_TARGET: http://host.docker.internal:8080
+      VITE_USE_EMULATOR: "true"
     ports:
       - "5173:5173"
       - "6006:6006"

--- a/packages/web/src/api/firebase.ts
+++ b/packages/web/src/api/firebase.ts
@@ -12,7 +12,7 @@ const app = initializeApp({
 
 const functions = getFunctions(app, "asia-northeast1");
 
-if (import.meta.env.DEV) {
+if (import.meta.env.VITE_USE_EMULATOR === "true") {
   connectFunctionsEmulator(functions, "localhost", 8080);
 }
 


### PR DESCRIPTION
# 概要

エミュレータ接続の判定を `import.meta.env.DEV` から `VITE_USE_EMULATOR` 環境変数に変更し、ローカル開発時のみエミュレータに接続するよう修正。あわせて README のデプロイ手順・環境変数セクションを更新。

## 種別

- [x] bug
- [ ] feature
- [ ] refactor
- [ ] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `firebase.ts`: 判定条件を `import.meta.env.VITE_USE_EMULATOR === "true"` に変更
- `docker-compose.yml`: `environment` に `VITE_USE_EMULATOR: "true"` を追加
- `README.md`: デプロイセクションに環境別ビルド手順を追記、環境変数テーブルを更新、エミュレータ接続の説明を更新
- `ADR-0004`: エミュレータ接続の記述を更新

# 変更理由（Why）

- `import.meta.env.DEV` は mode が `production` 以外で `true` になるため、`--mode development` や `--mode staging` でビルドしてデプロイすると、本番環境上でエミュレータに接続しようとする
- 「どの環境の設定を使うか」（mode）と「エミュレータに接続するか」を分離する必要がある

# 影響範囲（Impact）

- Backend: 影響なし
- Infra: docker-compose に環境変数追加。デプロイビルドの動作変更（エミュレータ接続しなくなる）

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [x] 境界値
- [x] 回帰影響なし

## 確認手順

1. `npm run docker:web:test` で全38テストが通過することを確認
2. `npm run docker:web:lint` で lint エラーがないことを確認

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過

---

# リスク・懸念点

- `VITE_USE_EMULATOR` が `.env` ファイルではなく docker-compose でのみ設定される点を理解していないと混乱する可能性がある（README に説明を記載済み）

# 関連 Issue

Closes #152

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある
- [x] ファイル I/O に適切なエラーハンドリングがある

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Functions エミュレータ接続の説明を見直し、ローカル開発での利用条件と env ファイルの適用タイミングを明確化。

* **設定変更**
  * エミュレータ接続制御が開発フラグから明示的な環境変数へ移行。Docker 開発環境での有効化を明記。

* **デプロイ**
  * ビルド／デプロイ時のモード指定を明示化するようドキュメントと設定を調整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->