### PR TITLE
fix(web): エミュレータ判定を Vite の command パラメータに変更

### DIFF
--- a/docs/adr/0004-web-frontend.md
+++ b/docs/adr/0004-web-frontend.md
@@ -31,7 +31,7 @@
 
 - `src/api/firebase.ts`: Firebase App + Functions の初期化（環境変数 `VITE_FIREBASE_*` を使用）
 - `src/api/parse-document.ts`: `httpsCallable` で Functions（onCall）を呼び出し
-- ローカル開発時は `connectFunctionsEmulator` でエミュレータに接続（`VITE_USE_EMULATOR` 環境変数で制御、docker-compose でのみ設定）
+- ローカル開発時は `connectFunctionsEmulator` でエミュレータに接続（Vite の dev サーバー実行時のみ自動有効化）
 - 環境変数は Vite の `.env.{mode}` ファイルで環境ごとに管理（`.env.development` / `.env.staging` / `.env.production`）
 
 ## 理由

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -134,11 +134,9 @@ Vite の [env ファイル読み込み規約](https://vite.dev/guide/env-and-mod
 
 ### Functions エミュレータ接続
 
-エミュレータ接続は環境変数 `VITE_USE_EMULATOR` で制御します。この変数は `.env` ファイルには設定せず、`docker-compose.yml` の `environment` でローカル開発時のみ注入されます。
+エミュレータ接続は Vite の `command` パラメータで自動判定されます（`vite.config.ts` の `define` で `__USE_EMULATOR__` を設定）。開発サーバー（`vite`）実行時のみエミュレータに接続し、ビルド（`vite build`）では mode に関係なく接続しません。
 
-| シナリオ                                 | `VITE_USE_EMULATOR`        | エミュレータ |
-| ---------------------------------------- | -------------------------- | ------------ |
-| ローカル開発（`docker:web:dev`）         | `"true"`（docker-compose） | 接続する     |
-| 開発環境デプロイ（`--mode development`） | 未設定                     | 接続しない   |
-| STG 環境デプロイ（`--mode staging`）     | 未設定                     | 接続しない   |
-| 本番デプロイ（`--mode production`）      | 未設定                     | 接続しない   |
+| シナリオ                         | Vite command | エミュレータ |
+| -------------------------------- | ------------ | ------------ |
+| ローカル開発（`docker:web:dev`） | serve        | 接続する     |
+| ビルド（全 mode 共通）           | build        | 接続しない   |

--- a/packages/web/docker/docker-compose.yml
+++ b/packages/web/docker/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     env_file: ../.env
     environment:
       API_PROXY_TARGET: http://host.docker.internal:8080
-      VITE_USE_EMULATOR: "true"
     ports:
       - "5173:5173"
       - "6006:6006"

--- a/packages/web/src/api/firebase.ts
+++ b/packages/web/src/api/firebase.ts
@@ -12,7 +12,7 @@ const app = initializeApp({
 
 const functions = getFunctions(app, "asia-northeast1");
 
-if (import.meta.env.VITE_USE_EMULATOR === "true") {
+if (__USE_EMULATOR__) {
   connectFunctionsEmulator(functions, "localhost", 8080);
 }
 

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __USE_EMULATOR__: boolean;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command, isPreview }) => ({
   plugins: [react()],
   define: {
-    __USE_EMULATOR__: command === "serve",
+    __USE_EMULATOR__: command === "serve" && !isPreview,
   },
 }));

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react()],
-});
+  define: {
+    __USE_EMULATOR__: command === "serve",
+  },
+}));

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     projects: [
       {
+        define: {
+          __USE_EMULATOR__: false,
+        },
         test: {
           name: "unit",
           include: ["src/**/*.test.{ts,tsx}"],


### PR DESCRIPTION
# 概要

エミュレータ接続の判定を `VITE_USE_EMULATOR` 環境変数から Vite の `command` パラメータによる自動判定に変更。

## 種別

- [x] bug
- [ ] feature
- [ ] refactor
- [ ] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `vite.config.ts`: `command === "serve"` で `__USE_EMULATOR__` グローバル定数を定義
- `vitest.config.ts`: テスト用に `__USE_EMULATOR__: false` を定義
- `vite-env.d.ts`: `__USE_EMULATOR__` の型宣言を追加
- `firebase.ts`: 判定条件を `__USE_EMULATOR__` に変更
- `docker-compose.yml`: 不要になった `VITE_USE_EMULATOR` を削除
- `README.md`: エミュレータ接続の説明を更新
- `ADR-0004`: エミュレータ接続の記述を更新

# 変更理由（Why）

- `VITE_USE_EMULATOR` を docker-compose の `environment` に設定する方式では、コンテナ内でのデプロイビルド時にもエミュレータ接続が有効になってしまう
- Vite の `command` パラメータ（`serve` / `build`）を使うことで、dev サーバー実行時のみエミュレータ接続を有効化し、ビルド時は mode に関係なく無効化できる

# 影響範囲（Impact）

- Backend: 影響なし
- Infra: docker-compose から `VITE_USE_EMULATOR` を削除

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [x] 境界値
- [x] 回帰影響なし

## 確認手順

1. `npm run docker:web:test:coverage` で全38テストが通過しカバレッジ閾値をクリアすることを確認
2. `npm run docker:web:lint` で lint エラーがないことを確認

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過

---

# リスク・懸念点

- `__USE_EMULATOR__` は Vite の `define` で注入されるグローバル定数のため、vitest でも同様に定義が必要（projects 内の `define` に設定済み）

# 関連 Issue

Closes #152

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある
- [x] ファイル I/O に適切なエラーハンドリングがある

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ローカル開発時のFirebase Functionsエミュレータ接続動作を簡潔化。開発サーバー実行時に自動的にエミュレータに接続するようになり、環境変数の手動管理が不要になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->