### PR TITLE
test(web): テスト作成ガイドラインに基づくテスト品質改善

### DIFF
--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -30,18 +30,18 @@ describe("AppView", () => {
     expect(screen.getByText("解析中...")).toBeInTheDocument();
   });
 
-  it("shows result table when result is available", () => {
-    render(
-      <AppView
-        {...defaultProps}
-        result={{
-          entities: [{ type: "total", mentionText: "1000", confidence: 0.95 }],
-        }}
-      />,
-    );
+  it("shows result table and raw data when result is available", () => {
+    const result = {
+      entities: [{ type: "total", mentionText: "1000", confidence: 0.95 }],
+    };
+    render(<AppView {...defaultProps} result={result} />);
 
     expect(screen.getByText("total")).toBeInTheDocument();
     expect(screen.getByText("1000")).toBeInTheDocument();
+    const details = screen.getByText("生データ");
+    expect(details).toBeInTheDocument();
+    const pre = details.closest("details")?.querySelector("pre");
+    expect(pre?.textContent).toBe(JSON.stringify(result, null, 2));
   });
 
   it("shows error message when error exists", () => {

--- a/packages/web/src/components/FileUploader.test.tsx
+++ b/packages/web/src/components/FileUploader.test.tsx
@@ -81,6 +81,21 @@ describe("FileUploader", () => {
     expect(screen.queryByText("選択済み: test.txt")).not.toBeInTheDocument();
   });
 
+  it("resets file when unsupported MIME type is selected via input", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<FileUploader onSubmit={onSubmit} disabled={false} />);
+
+    const input = screen.getByLabelText("ファイル");
+    const validFile = new File(["content"], "test.png", { type: "image/png" });
+    await user.upload(input, validFile);
+    expect(screen.getByText("選択済み: test.png")).toBeInTheDocument();
+
+    const invalidFile = new File(["content"], "test.gif", { type: "image/gif" });
+    await user.upload(input, invalidFile);
+    expect(screen.queryByText(/選択済み:/)).not.toBeInTheDocument();
+  });
+
   it("ignores drop when no files", () => {
     render(<FileUploader onSubmit={vi.fn()} disabled={false} />);
 

--- a/packages/web/src/components/PasswordGate.test.tsx
+++ b/packages/web/src/components/PasswordGate.test.tsx
@@ -44,4 +44,24 @@ describe("PasswordGate", () => {
     expect(screen.getByText("パスワードが正しくありません")).toBeInTheDocument();
     expect(screen.queryByText("protected content")).not.toBeInTheDocument();
   });
+
+  it("エラー後に正しいパスワードで認証成功する", async () => {
+    const user = userEvent.setup();
+    render(
+      <PasswordGate password="secret">
+        <p>protected content</p>
+      </PasswordGate>,
+    );
+
+    await user.type(screen.getByPlaceholderText("パスワード"), "wrong");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+    expect(screen.getByText("パスワードが正しくありません")).toBeInTheDocument();
+
+    await user.clear(screen.getByPlaceholderText("パスワード"));
+    await user.type(screen.getByPlaceholderText("パスワード"), "secret");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(screen.getByText("protected content")).toBeInTheDocument();
+    expect(screen.queryByText("パスワードが正しくありません")).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/components/ResultTable.test.tsx
+++ b/packages/web/src/components/ResultTable.test.tsx
@@ -34,6 +34,11 @@ describe("ResultTable", () => {
     expect(screen.getByText("date")).toBeInTheDocument();
     expect(screen.getByText("2024-01-01")).toBeInTheDocument();
     expect(screen.getByText("88.0%")).toBeInTheDocument();
+
+    const rows = screen.getAllByRole("row");
+    const dateRow = rows[2];
+    const cells = dateRow.querySelectorAll("td");
+    expect(cells[3]).toHaveTextContent("");
   });
 
   it("renders empty state when no entities", () => {

--- a/packages/web/src/hooks/useParseDocument.test.ts
+++ b/packages/web/src/hooks/useParseDocument.test.ts
@@ -99,6 +99,51 @@ describe("useParseDocument", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it("再実行時に前回のエラーがクリアされる", async () => {
+    vi.mocked(fileUtils.fileToBase64).mockResolvedValue("base64data");
+    vi.mocked(parseDocumentApi.parseDocument)
+      .mockRejectedValueOnce(new Error("Server error"))
+      .mockResolvedValueOnce({ entities: [] });
+
+    const { result } = renderHook(() => useParseDocument());
+    const file = new File(["content"], "test.png", { type: "image/png" });
+
+    await act(async () => {
+      await result.current.submit(file);
+    });
+    expect(result.current.error).toBe("Server error");
+
+    await act(async () => {
+      await result.current.submit(file);
+    });
+    expect(result.current.error).toBe("");
+    expect(result.current.result).toEqual({ entities: [] });
+  });
+
+  it("再実行時に前回の結果がクリアされる", async () => {
+    const firstResponse = {
+      entities: [{ type: "total", mentionText: "1000", confidence: 0.95 }],
+    };
+    vi.mocked(fileUtils.fileToBase64).mockResolvedValue("base64data");
+    vi.mocked(parseDocumentApi.parseDocument)
+      .mockResolvedValueOnce(firstResponse)
+      .mockRejectedValueOnce(new Error("Server error"));
+
+    const { result } = renderHook(() => useParseDocument());
+    const file = new File(["content"], "test.png", { type: "image/png" });
+
+    await act(async () => {
+      await result.current.submit(file);
+    });
+    expect(result.current.result).toEqual(firstResponse);
+
+    await act(async () => {
+      await result.current.submit(file);
+    });
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBe("Server error");
+  });
+
   it("sets isLoading during submission", async () => {
     const loadingStates: boolean[] = [];
     let resolveApi: (value: unknown) => void;

--- a/packages/web/src/utils/file.test.ts
+++ b/packages/web/src/utils/file.test.ts
@@ -30,4 +30,21 @@ describe("fileToBase64", () => {
     expect(result).not.toContain("data:");
     expect(result).not.toContain("base64,");
   });
+
+  it("rejects when FileReader fails", async () => {
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+
+    const originalFileReader = globalThis.FileReader;
+    const mockError = new DOMException("Read failed");
+    globalThis.FileReader = class extends originalFileReader {
+      readAsDataURL() {
+        Object.defineProperty(this, "error", { value: mockError });
+        this.onerror?.(new ProgressEvent("error"));
+      }
+    } as typeof FileReader;
+
+    await expect(fileToBase64(file)).rejects.toBe(mockError);
+
+    globalThis.FileReader = originalFileReader;
+  });
 });


### PR DESCRIPTION
# 概要

web パッケージのテストファイルをテスト作成ガイドライン（`.claude/skills/write-tests.md`）に基づいてレビューし、品質改善を実施。

## 種別

- [x] test

---

# 変更内容（What）

- `useParseDocument.test.ts`: 再実行時に前回のエラー・結果がクリアされる状態遷移テスト追加
- `file.test.ts`: `fileToBase64` の `reader.onerror` パス（FileReader 失敗時の reject）テスト追加
- `FileUploader.test.tsx`: `<input>` 経由で非サポート MIME タイプ選択時にファイルがリセットされる振る舞いテスト追加
- `PasswordGate.test.tsx`: 間違ったパスワード入力後に正しいパスワードで認証成功するフローのテスト追加
- `ResultTable.test.tsx`: `normalizedValue` 未設定のエンティティ行で正規化値セルが空文字になることを明示的に検証
- `App.test.tsx`: `result` 存在時に「生データ」details 要素と JSON 内容が表示されることを検証

# 変更理由（Why）

- `useParseDocument` の状態クリアロジック（`setError("")`, `setResult(null)`）が未検証で、連続操作時の状態不整合を見逃すリスクがあった
- `fileToBase64` の `reader.onerror` パスはファイル読み込み失敗で実際に発生しうる振る舞い
- `FileUploader` の `onChange` 内の `isValidMimeType` 判定がドロップ側のみテストされていた
- `PasswordGate` のエラークリア（`setError(false)`）がユーザーの最も自然なフローで未検証だった
- `normalizedValue?.text ?? ""` の fallback がテストで明示的に保証されていなかった
- `AppView` の `<details>` 生データ表示が未テストだった

# 影響範囲（Impact）

- Backend: なし（テストのみ）
- Infra: なし

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [x] 境界値
- [x] 回帰影響なし

## 確認手順

1. `npm run docker:web:test` で全 43 テストが pass
2. `npm run docker:web:lint` で lint エラーなし

---

# テスト

- [x] 単体テスト追加／更新
- [ ] 統合テスト追加／更新（該当なし）
- [x] 既存テスト通過

---

# リスク・懸念点

- テストコードのみの変更で、プロダクションコードへの変更なし

# 関連 Issue

Closes #161

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（該当なし）
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（該当なし）
- [x] ファイル I/O に適切なエラーハンドリングがある（該当なし）

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない