### PR TITLE
fix(functions): API_KEY 未設定時に認証がバイパスされる問題を修正

### DIFF
--- a/packages/functions/src/infrastructure/auth-validator.test.ts
+++ b/packages/functions/src/infrastructure/auth-validator.test.ts
@@ -31,4 +31,9 @@ describe("validateApiKey", () => {
     const result = validateApiKey("Bearer ", validKey);
     expect(result).toEqual({ ok: false, message: "無効な API キーです。" });
   });
+
+  it("validApiKey が空文字の場合、認証失敗", () => {
+    const result = validateApiKey("Bearer any-key", "");
+    expect(result).toEqual({ ok: false, message: "API キーが設定されていません。" });
+  });
 });

--- a/packages/functions/src/infrastructure/auth-validator.ts
+++ b/packages/functions/src/infrastructure/auth-validator.ts
@@ -11,6 +11,10 @@ export function validateApiKey(
   authorizationHeader: string | undefined,
   validApiKey: string,
 ): AuthSuccess | AuthError {
+  if (!validApiKey) {
+    return { ok: false, message: "API キーが設定されていません。" };
+  }
+
   if (!authorizationHeader) {
     return { ok: false, message: "認証が必要です。" };
   }


### PR DESCRIPTION
# 概要

`handleParseDocument`（onRequest ハンドラ）で `API_KEY` 環境変数が未設定の場合、空文字同士の比較により認証が通過する脆弱性を修正。

## 種別

- [x] fix

---

# 変更内容（What）

- `auth-validator.ts`: `validApiKey` が空文字の場合に「API キーが設定されていません。」エラーを早期に返すガードを追加
- `auth-validator.test.ts`: `validApiKey` が空文字の場合の認証失敗テストを追加

# 変更理由（Why）

- `process.env.API_KEY ?? ""` で fallback した空文字が `validateApiKey` に渡されると、`Bearer `（Bearer + 空文字）送信で `"" === ""` となり認証が通過する
- Secret Manager の設定漏れ時にサイレントに全リクエストが通過するリスクがあった

# 影響範囲（Impact）

- Backend: `parseDocumentHttp`（onRequest）のみ。`parseDocumentCall`（onCall）は API キー認証を使用しないため影響なし
- Infra: なし

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. `npm run docker:functions:test` で全 38 テストが pass
2. `validApiKey` が空文字の場合に認証失敗となることをテストで確認

---

# テスト

- [x] 単体テスト追加／更新
- [ ] 統合テスト追加／更新（該当なし）
- [x] 既存テスト通過

---

# リスク・懸念点

- `API_KEY` が未設定の環境（ローカル開発等）では onRequest エンドポイントが常に 401 を返すようになる。ローカルでは onCall 側を使用するため影響は限定的

# 関連 Issue

Closes #165

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（該当なし）
- [x] ファイル I/O に適切なエラーハンドリングがある（該当なし）

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * APIキーが設定されていない場合、適切なエラーメッセージを返すように検証ロジックを改善しました。

* **テスト**
  * 空のAPIキーをハンドルするテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->