### PR TITLE
fix(web): fileToBase64 のエラーメッセージをユーザー向けに変換

### DIFF
--- a/packages/web/src/hooks/useParseDocument.test.ts
+++ b/packages/web/src/hooks/useParseDocument.test.ts
@@ -84,6 +84,21 @@ describe("useParseDocument", () => {
     expect(parseDocumentApi.parseDocument).not.toHaveBeenCalled();
   });
 
+  it("ファイル読み込み失敗時にユーザー向けメッセージを表示する", async () => {
+    vi.mocked(fileUtils.fileToBase64).mockRejectedValue(new DOMException("Read failed"));
+
+    const { result } = renderHook(() => useParseDocument());
+    const file = new File(["content"], "test.png", { type: "image/png" });
+
+    await act(async () => {
+      await result.current.submit(file);
+    });
+
+    expect(result.current.error).toBe("ファイルの読み込みに失敗しました");
+    expect(result.current.isLoading).toBe(false);
+    expect(parseDocumentApi.parseDocument).not.toHaveBeenCalled();
+  });
+
   it("handles non-Error thrown values", async () => {
     vi.mocked(fileUtils.fileToBase64).mockResolvedValue("base64data");
     vi.mocked(parseDocumentApi.parseDocument).mockRejectedValue("string error");

--- a/packages/web/src/hooks/useParseDocument.ts
+++ b/packages/web/src/hooks/useParseDocument.ts
@@ -29,7 +29,14 @@ export function useParseDocument(): UseParseDocumentReturn {
     setResult(null);
 
     try {
-      const content = await fileToBase64(file);
+      let content: string;
+      try {
+        content = await fileToBase64(file);
+      } catch {
+        setError("ファイルの読み込みに失敗しました");
+        return;
+      }
+
       const response = await parseDocument({ content, mimeType: file.type });
       setResult(response);
     } catch (err) {


### PR DESCRIPTION
# 概要

`fileToBase64` の失敗時にブラウザ内部のエラーメッセージがそのままユーザーに表示される問題を修正。

## 種別

- [x] fix

---

# 変更内容（What）

- `useParseDocument.ts`: `fileToBase64` を個別の try-catch で包み、失敗時は「ファイルの読み込みに失敗しました」の固定メッセージを表示
- `useParseDocument.test.ts`: `fileToBase64` 失敗時のテストケース追加

# 変更理由（Why）

- `DOMException` の `message` は英語で出ることが多く、ユーザーにとって意味不明な文字列になる
- `fileToBase64`（ファイル読み込み）と `parseDocument`（API 呼び出し）のエラーは性質が異なるため区別すべき

# 影響範囲（Impact）

- Backend: なし
- Infra: なし

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [ ] 境界値（該当なし）
- [x] 回帰影響なし

## 確認手順

1. `npm run docker:web:test` で全 44 テストが pass
2. `fileToBase64` 失敗時にユーザー向けメッセージが表示されることをテストで確認
3. API エラー時の既存動作（エラーメッセージ表示）に変更がないことを確認

---

# テスト

- [x] 単体テスト追加／更新
- [ ] 統合テスト追加／更新（該当なし）
- [x] 既存テスト通過

---

# リスク・懸念点

- なし

# 関連 Issue

Closes #169

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（該当なし）
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある
- [x] ファイル I/O に適切なエラーハンドリングがある

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ファイル読み込みエラーが発生した際に、ユーザーフレンドリーなエラーメッセージ「ファイルの読み込みに失敗しました」が表示されるようになりました。エラー発生時はローディング状態が正しくリセットされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->