### PR TITLE
web パッケージに結合テストを追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "docker:web:format:check": "docker-compose -f packages/web/docker/docker-compose.yml run --rm web npm run format:check",
     "docker:web:test": "docker-compose -f packages/web/docker/docker-compose.yml run --rm web npm run test",
     "docker:web:test:coverage": "docker-compose -f packages/web/docker/docker-compose.yml run --rm web npm run test:coverage",
+    "docker:web:test:integration": "docker-compose -f packages/web/docker/docker-compose.yml run --rm web npm run test:integration",
     "docker:web:storybook": "docker-compose -f packages/web/docker/docker-compose.yml run --rm --service-ports web bash -c 'npm run build:storybook && npx http-server storybook-static -p 6006 -a 0.0.0.0 --silent'",
     "docker:web:build:storybook": "docker-compose -f packages/web/docker/docker-compose.yml run --rm web npm run build:storybook",
     "docker:web:test:visual": "docker-compose -f packages/web/docker/docker-compose.yml run --rm playwright npx playwright test",

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -7,7 +7,8 @@ React + Vite による Web フロントエンドです。ファイルをアッ�
 ```bash
 npm run docker:web:lint                # ESLint 実行
 npm run docker:web:format:check        # Prettier チェック
-npm run docker:web:test                # テスト実行
+npm run docker:web:test                # テスト実行（全テスト）
+npm run docker:web:test:integration    # 結合テストのみ実行
 npm run docker:web:test:coverage       # テスト + カバレッジ計測
 npm run docker:web:dev                 # 開発サーバー起動
 npm run docker:web:sh                  # コンテナに入って操作
@@ -27,12 +28,25 @@ npm run build            # TypeScript + Vite ビルド
 npm run dev -- --host    # 開発サーバー起動（--host 必須）
 npm run lint:fix         # ESLint 自動修正
 npm run format           # Prettier フォーマット
+npm run test             # テスト実行（全テスト）
 npm run test:unit        # ユニットテストのみ
+npm run test:integration # 結合テストのみ
 npm run storybook -- --host 0.0.0.0  # Storybook 開発サーバー起動（--host 必須）
 npm run build:storybook  # Storybook 静的ビルド
 npm run test:coverage    # テスト + カバレッジ計測
 npm run test:watch       # テスト実行（ウォッチモード）
 ```
+
+## テスト構成
+
+テストは Vitest のプロジェクト機能で **unit**（単体テスト）と **integration**（結合テスト）に分離しています。
+
+| 種別        | 配置場所                          | 説明                                                          |
+| ----------- | --------------------------------- | ------------------------------------------------------------- |
+| unit        | `src/**/*.test.{ts,tsx}`          | ソースコードと同じディレクトリに配置。依存は個別にモック      |
+| integration | `tests/integration/**/*.test.tsx` | App を実際の依存グラフで結合して検証。Firebase SDK のみモック |
+
+結合テストのヘルパー（フィクスチャ・モック）は `tests/integration/helpers/` にまとめています。
 
 ## ローカル実行
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,6 +14,7 @@
     "format:check": "prettier --check src/",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
+    "test:integration": "vitest run --project integration",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:visual": "playwright test",

--- a/packages/web/tests/integration/app.test.tsx
+++ b/packages/web/tests/integration/app.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockCallable } from "./helpers/mock-firebase";
+import { MOCK_ENTITIES, MOCK_API_RESPONSE, createTestFile } from "./helpers/fixtures";
+import { App } from "../../src/App";
+
+describe("App（結合テスト）", () => {
+  beforeEach(() => {
+    mockCallable.mockReset();
+  });
+
+  it("正常系: ファイル選択 → 解析 → ResultTable に結果が表示される", async () => {
+    mockCallable.mockResolvedValue(MOCK_API_RESPONSE);
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    const fileInput = screen.getByLabelText("ファイル");
+    const file = createTestFile();
+    await user.upload(fileInput, file);
+
+    const submitButton = screen.getByRole("button", { name: "解析" });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("1,234")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("total_amount")).toBeInTheDocument();
+    expect(screen.getByText("95.0%")).toBeInTheDocument();
+    expect(screen.getByText("date")).toBeInTheDocument();
+    expect(screen.getByText("2024-01-15")).toBeInTheDocument();
+
+    expect(mockCallable).toHaveBeenCalledWith({
+      content: expect.any(String),
+      mimeType: "application/pdf",
+    });
+  });
+
+  it("バリデーションエラー: サポート外ファイルは FileUploader が拒否し、解析ボタンが無効のまま", async () => {
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    const fileInput = screen.getByLabelText("ファイル");
+    const file = createTestFile("document.txt", "text/plain");
+    await user.upload(fileInput, file);
+
+    const submitButton = screen.getByRole("button", { name: "解析" });
+    expect(submitButton).toBeDisabled();
+    expect(screen.queryByText("選択済み:")).not.toBeInTheDocument();
+    expect(mockCallable).not.toHaveBeenCalled();
+  });
+
+  it("API エラー: Firebase Functions 失敗で ErrorMessage を表示する", async () => {
+    mockCallable.mockRejectedValue(new Error("Functions エラー"));
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    const fileInput = screen.getByLabelText("ファイル");
+    const file = createTestFile();
+    await user.upload(fileInput, file);
+
+    const submitButton = screen.getByRole("button", { name: "解析" });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Functions エラー");
+    expect(mockCallable).toHaveBeenCalled();
+  });
+
+  it("ローディング状態: 解析中に表示され、完了後に消える", async () => {
+    let resolveCallable!: (value: typeof MOCK_API_RESPONSE) => void;
+    mockCallable.mockImplementation(
+      () => new Promise((resolve) => { resolveCallable = resolve; }),
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    const fileInput = screen.getByLabelText("ファイル");
+    const file = createTestFile();
+    await user.upload(fileInput, file);
+
+    const submitButton = screen.getByRole("button", { name: "解析" });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("解析中...")).toBeInTheDocument();
+    });
+
+    resolveCallable(MOCK_API_RESPONSE);
+
+    await waitFor(() => {
+      expect(screen.queryByText("解析中...")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/integration/helpers/fixtures.ts
+++ b/packages/web/tests/integration/helpers/fixtures.ts
@@ -1,0 +1,16 @@
+import type { Entity } from "../../../src/api/types";
+
+export const MOCK_ENTITIES: Entity[] = [
+  { type: "total_amount", mentionText: "1,234", confidence: 0.95 },
+  { type: "date", mentionText: "2024-01-15", confidence: 0.9 },
+];
+
+export const MOCK_API_RESPONSE = { data: { entities: MOCK_ENTITIES } };
+
+export function createTestFile(
+  name: string = "receipt.pdf",
+  type: string = "application/pdf",
+  content: string = "dummy-content",
+): File {
+  return new File([content], name, { type });
+}

--- a/packages/web/tests/integration/helpers/mock-firebase.ts
+++ b/packages/web/tests/integration/helpers/mock-firebase.ts
@@ -1,0 +1,13 @@
+import { vi } from "vitest";
+
+export const mockCallable = vi.fn();
+
+vi.mock("firebase/app", () => ({
+  initializeApp: vi.fn(),
+}));
+
+vi.mock("firebase/functions", () => ({
+  getFunctions: vi.fn(),
+  connectFunctionsEmulator: vi.fn(),
+  httpsCallable: vi.fn(() => mockCallable),
+}));

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -14,6 +14,17 @@ export default defineConfig({
           setupFiles: ["src/test-setup.ts"],
         },
       },
+      {
+        define: {
+          __USE_EMULATOR__: false,
+        },
+        test: {
+          name: "integration",
+          include: ["tests/integration/**/*.test.{ts,tsx}"],
+          environment: "jsdom",
+          setupFiles: ["src/test-setup.ts"],
+        },
+      },
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
# 概要

web パッケージに「外部境界（Firebase SDK）だけモックし、内部レイヤーは実コードで結合する」レベルの結合テストを追加する。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [ ] chore
- [ ] docs
- [x] test

---

# 変更内容（What）

- `tests/integration/helpers/mock-firebase.ts` — Firebase SDK（firebase/app, firebase/functions）のモック
- `tests/integration/helpers/fixtures.ts` — テストデータ・ヘルパー関数
- `tests/integration/app.test.tsx` — App コンポーネントの結合テスト（4ケース）
  - 正常系: ファイル選択 → 解析 → ResultTable に結果表示
  - バリデーション: サポート外ファイルは FileUploader が拒否、解析ボタン無効
  - API エラー: Firebase Functions 失敗時に ErrorMessage 表示
  - ローディング状態: 解析中表示 → 完了後に消える
- `vitest.config.ts` に integration プロジェクトを追加
- `test:integration` スクリプトを追加（web package.json + ルート package.json）
- README.md にテスト構成セクションと結合テストコマンドを追加

# 変更理由（Why）

- functions パッケージでは結合テストが整備されていたが、web パッケージにはなかった
- App → useParseDocument → parseDocument → Firebase SDK の一気通貫フローをテストし、内部レイヤーの結合を検証する

# 影響範囲（Impact）

- Backend: なし
- Infra: なし（テスト追加のみ）

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. `npm run docker:web:test:integration` → 4テスト全パス
2. `npm run docker:web:test` → 9ファイル 48テスト全パス（unit 44 + integration 4）
3. `npm run docker:web:lint` → 成功

---

# テスト

- [ ] 単体テスト追加／更新
- [x] 統合テスト追加／更新
- [x] 既存テスト通過

---

# リスク・懸念点

- 特になし

# 関連 Issue

Closes #181

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある
- [x] ファイル I/O に適切なエラーハンドリングがある

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない