### PR TITLE
hosting predeploy の --workspace フラグを --prefix に変更する

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -13,7 +13,7 @@
         "destination": "/index.html"
       }
     ],
-    "predeploy": "npm run build -w @docai/web -- --mode ${VITE_MODE:-production}"
+    "predeploy": "npm --prefix packages/web run build -- --mode ${VITE_MODE:-production}"
   },
   "emulators": {
     "functions": {


### PR DESCRIPTION
# 概要

firebase.json の hosting predeploy コマンドを npm workspaces 削除後の構成に合わせて修正する。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [ ] chore
- [ ] docs
- [ ] test
- [x] fix

---

# 変更内容（What）

- `npm run build -w @docai/web -- --mode ${VITE_MODE:-production}` を `npm --prefix packages/web run build -- --mode ${VITE_MODE:-production}` に変更

# 変更理由（Why）

- #176 で npm workspaces を削除したが、firebase.json の hosting predeploy が未修正だった
- `firebase deploy --only hosting` 実行時に `No workspaces found` エラーが発生していた

# 影響範囲（Impact）

- Backend: なし
- Infra: Hosting デプロイの predeploy コマンド

---

# 動作確認

## 確認観点

- [x] 正常系
- [ ] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. `firebase deploy --only hosting` でデプロイが成功すること

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過

---

# リスク・懸念点

- 特になし

# 関連 Issue

Closes #183

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 影響範囲を確認済み

### 変更範囲

- [x] PR が1つの目的に絞られている