### PR TITLE
refactor(functions): DDD 用語整理と MimeType 値オブジェクト化

### DIFF
--- a/packages/functions/src/application/parse-document.test.ts
+++ b/packages/functions/src/application/parse-document.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { parseDocument } from "./parse-document.js";
 import type { DocumentProcessor } from "./parse-document.js";
+import { MimeType } from "../domain/mime-type.js";
 
 describe("parseDocument", () => {
   const mockEntities = [{ type: "total_amount", mentionText: "1,234", confidence: 0.95 }];
@@ -17,7 +18,7 @@ describe("parseDocument", () => {
         location: "us",
         processorId: "proc-123",
         content: "base64content",
-        mimeType: "application/pdf",
+        mimeType: MimeType.from("application/pdf"),
       },
       processor,
     );

--- a/packages/functions/src/application/parse-document.ts
+++ b/packages/functions/src/application/parse-document.ts
@@ -1,8 +1,10 @@
+import type { MimeType } from "../domain/mime-type.js";
+
 export interface DocumentProcessor {
-  process(params: { name: string; content: string; mimeType: string }): Promise<DocumentEntity[]>;
+  process(params: { name: string; content: string; mimeType: string }): Promise<ExtractedField[]>;
 }
 
-export interface DocumentEntity {
+export interface ExtractedField {
   type?: string | null;
   mentionText?: string | null;
   confidence?: number | null;
@@ -14,18 +16,18 @@ export interface ParseDocumentParams {
   location: string;
   processorId: string;
   content: string;
-  mimeType: string;
+  mimeType: MimeType;
 }
 
 export async function parseDocument(
   params: ParseDocumentParams,
   processor: DocumentProcessor,
-): Promise<DocumentEntity[]> {
+): Promise<ExtractedField[]> {
   const name = `projects/${params.projectId}/locations/${params.location}/processors/${params.processorId}`;
 
   return processor.process({
     name,
     content: params.content,
-    mimeType: params.mimeType,
+    mimeType: params.mimeType.value,
   });
 }

--- a/packages/functions/src/domain/mime-type.test.ts
+++ b/packages/functions/src/domain/mime-type.test.ts
@@ -1,24 +1,37 @@
 import { describe, it, expect } from "vitest";
-import { isSupportedMimeType } from "./mime-type.js";
+import { MimeType, UnsupportedMimeTypeError } from "./mime-type.js";
 
-describe("isSupportedMimeType", () => {
-  it("application/pdf はサポート対象", () => {
-    expect(isSupportedMimeType("application/pdf")).toBe(true);
+describe("MimeType", () => {
+  describe("from", () => {
+    it.each(["application/pdf", "image/png", "image/jpeg"])(
+      "サポート対象 %s から MimeType を生成できる",
+      (value) => {
+        const mimeType = MimeType.from(value);
+        expect(mimeType).toBeInstanceOf(MimeType);
+        expect(mimeType.value).toBe(value);
+      },
+    );
+
+    it("サポート外の mimeType で UnsupportedMimeTypeError を投げる", () => {
+      expect(() => MimeType.from("image/tiff")).toThrow(UnsupportedMimeTypeError);
+    });
+
+    it("空文字でも UnsupportedMimeTypeError を投げる", () => {
+      expect(() => MimeType.from("")).toThrow(UnsupportedMimeTypeError);
+    });
+
+    it("例外メッセージに対応形式の一覧が含まれる", () => {
+      expect(() => MimeType.from("image/tiff")).toThrow(
+        "サポートされていない mimeType: image/tiff。対応形式: application/pdf, image/png, image/jpeg",
+      );
+    });
   });
+});
 
-  it("image/png はサポート対象", () => {
-    expect(isSupportedMimeType("image/png")).toBe(true);
-  });
-
-  it("image/jpeg はサポート対象", () => {
-    expect(isSupportedMimeType("image/jpeg")).toBe(true);
-  });
-
-  it("image/tiff はサポート対象外", () => {
-    expect(isSupportedMimeType("image/tiff")).toBe(false);
-  });
-
-  it("空文字はサポート対象外", () => {
-    expect(isSupportedMimeType("")).toBe(false);
+describe("UnsupportedMimeTypeError", () => {
+  it("不正値を value プロパティに保持する", () => {
+    const error = new UnsupportedMimeTypeError("image/tiff");
+    expect(error.value).toBe("image/tiff");
+    expect(error.name).toBe("UnsupportedMimeTypeError");
   });
 });

--- a/packages/functions/src/domain/mime-type.ts
+++ b/packages/functions/src/domain/mime-type.ts
@@ -1,5 +1,19 @@
-const SUPPORTED_MIME_TYPES = new Set(["application/pdf", "image/png", "image/jpeg"]);
+const SUPPORTED_MIME_TYPES = ["application/pdf", "image/png", "image/jpeg"] as const;
 
-export function isSupportedMimeType(mimeType: string): boolean {
-  return SUPPORTED_MIME_TYPES.has(mimeType);
+export class UnsupportedMimeTypeError extends Error {
+  constructor(public readonly value: string) {
+    super(`サポートされていない mimeType: ${value}。対応形式: ${SUPPORTED_MIME_TYPES.join(", ")}`);
+    this.name = "UnsupportedMimeTypeError";
+  }
+}
+
+export class MimeType {
+  private constructor(public readonly value: string) {}
+
+  static from(value: string): MimeType {
+    if (!(SUPPORTED_MIME_TYPES as readonly string[]).includes(value)) {
+      throw new UnsupportedMimeTypeError(value);
+    }
+    return new MimeType(value);
+  }
 }

--- a/packages/functions/src/handlers/parse-document-call.ts
+++ b/packages/functions/src/handlers/parse-document-call.ts
@@ -2,11 +2,11 @@ import { HttpsError, type CallableRequest } from "firebase-functions/v2/https";
 import { validateParseDocumentRequest } from "../infrastructure/request-validator.js";
 import { loadFunctionsConfig } from "../infrastructure/config.js";
 import { createDocumentProcessor } from "../infrastructure/document-ai-client.js";
-import { parseDocument, type DocumentEntity } from "../application/parse-document.js";
+import { parseDocument, type ExtractedField } from "../application/parse-document.js";
 
 export const handleParseDocumentCall = async (
   request: CallableRequest,
-): Promise<{ entities: DocumentEntity[] }> => {
+): Promise<{ entities: ExtractedField[] }> => {
   const validation = validateParseDocumentRequest(request.data);
   if (!validation.ok) {
     throw new HttpsError("invalid-argument", validation.message);

--- a/packages/functions/src/infrastructure/document-ai-client.ts
+++ b/packages/functions/src/infrastructure/document-ai-client.ts
@@ -1,5 +1,5 @@
 import { DocumentProcessorServiceClient } from "@google-cloud/documentai";
-import type { DocumentProcessor, DocumentEntity } from "../application/parse-document.js";
+import type { DocumentProcessor, ExtractedField } from "../application/parse-document.js";
 
 export function createDocumentProcessor(location: string): DocumentProcessor {
   const client = new DocumentProcessorServiceClient({
@@ -11,14 +11,14 @@ export function createDocumentProcessor(location: string): DocumentProcessor {
       name: string;
       content: string;
       mimeType: string;
-    }): Promise<DocumentEntity[]> {
+    }): Promise<ExtractedField[]> {
       const [result] = await client.processDocument({
         name: params.name,
         rawDocument: { content: params.content, mimeType: params.mimeType },
       });
 
       const entities = result.document?.entities ?? [];
-      return entities as DocumentEntity[];
+      return entities as ExtractedField[];
     },
   };
 }

--- a/packages/functions/src/infrastructure/request-validator.test.ts
+++ b/packages/functions/src/infrastructure/request-validator.test.ts
@@ -1,16 +1,19 @@
 import { describe, it, expect } from "vitest";
 import { validateParseDocumentRequest } from "./request-validator.js";
+import { MimeType } from "../domain/mime-type.js";
 
 describe("validateParseDocumentRequest", () => {
-  it("有効なリクエストを受け付ける", () => {
+  it("有効なリクエストを受け付け、mimeType は MimeType インスタンスになる", () => {
     const result = validateParseDocumentRequest({
       content: "base64data",
       mimeType: "application/pdf",
     });
-    expect(result).toEqual({
-      ok: true,
-      data: { content: "base64data", mimeType: "application/pdf" },
-    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.content).toBe("base64data");
+    expect(result.data.mimeType).toBeInstanceOf(MimeType);
+    expect(result.data.mimeType.value).toBe("application/pdf");
   });
 
   it("bodyがnullの場合、エラーを返す", () => {

--- a/packages/functions/src/infrastructure/request-validator.ts
+++ b/packages/functions/src/infrastructure/request-validator.ts
@@ -1,8 +1,8 @@
-import { isSupportedMimeType } from "../domain/mime-type.js";
+import { MimeType, UnsupportedMimeTypeError } from "../domain/mime-type.js";
 
 export interface ParseDocumentRequest {
   content: string;
-  mimeType: string;
+  mimeType: MimeType;
 }
 
 export interface ValidationResult {
@@ -30,15 +30,18 @@ export function validateParseDocumentRequest(body: unknown): ValidationResult | 
     return { ok: false, message: "mimeType は必須で、空でない文字列である必要があります" };
   }
 
-  if (!isSupportedMimeType(obj.mimeType)) {
-    return {
-      ok: false,
-      message: `サポートされていない mimeType: ${obj.mimeType}。対応形式: application/pdf, image/png, image/jpeg`,
-    };
+  let mimeType: MimeType;
+  try {
+    mimeType = MimeType.from(obj.mimeType);
+  } catch (e) {
+    if (e instanceof UnsupportedMimeTypeError) {
+      return { ok: false, message: e.message };
+    }
+    throw e;
   }
 
   return {
     ok: true,
-    data: { content: obj.content, mimeType: obj.mimeType },
+    data: { content: obj.content, mimeType },
   };
 }


### PR DESCRIPTION
# 概要

ADR-0009 の方針に基づき、`packages/functions` のドメイン用語を整理し、`MimeType` を値オブジェクトとして導入する。

## 種別

- [ ] bug
- [ ] feature
- [x] refactor
- [ ] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- **`DocumentEntity` 型を `ExtractedField` にリネーム**
  - DDD の Entity と命名衝突するため
  - `application/parse-document.ts`、`infrastructure/document-ai-client.ts`、`handlers/parse-document-call.ts` を追従
  - HTTP レスポンスの JSON キー `entities` は API 互換のため変更しない
- **`MimeType` を値オブジェクト化**
  - `domain/mime-type.ts` を `MimeType` クラスに（`private constructor` + `static from()`）
  - 不正な MIME タイプは `UnsupportedMimeTypeError`（ドメイン例外）を throw
  - `infrastructure/request-validator.ts` で `try/catch` し、既存の `ValidationError` 値返却スタイルに変換（境界で 4xx 正規化／ADR-0009 準拠）
  - `application/parse-document.ts` の `ParseDocumentParams.mimeType` を `MimeType` 型に変更
  - `processor.process()` には `MimeType.value` で生文字列を渡す（infrastructure 境界で剥がす）
- **テスト更新**
  - `domain/mime-type.test.ts`: `MimeType.from()` の正常系・異常系・例外メッセージ
  - `infrastructure/request-validator.test.ts`: `data.mimeType` が `MimeType` インスタンスであることを検証
  - `application/parse-document.test.ts`: `MimeType.from()` 経由で値を渡す形に修正

---

# 変更理由（Why）

- ADR-0009 で「値オブジェクトのみ採用」「ドメイン例外は境界層で 4xx 正規化」の方針を決定（#199、#200）
- 現状の `domain/mime-type.ts` は単なる関数で、値オブジェクトの形を取っていなかった
- `DocumentEntity` 型は将来 DDD の Entity を導入する際に命名衝突するため、先回りでリネーム
- 値オブジェクト化により「不正な MIME タイプを持つインスタンスは存在し得ない」という型安全性を得る

---

# 影響範囲（Impact）

- Backend: `packages/functions` のドメイン層・アプリケーション層・インフラ層・ハンドラ層を横断
  - 内部の型変更のみ。HTTP レスポンスの形式は変更なし（`{ entities: [...] }`、JSON キーは互換）
  - リクエスト受付仕様は変更なし（同じ MIME タイプを受け付け、同じエラーメッセージを返す）
- Infra: なし

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [x] 境界値
- [x] 回帰影響なし

## 確認手順

```bash
npm run docker:functions:lint           # eslint
npm run docker:functions:format:check   # prettier
npm run docker:functions:test:unit      # 40 tests passed
npm run docker:functions:test:integration  # 9 tests passed
npm run docker:functions:build          # tsc
```

すべてパス。

---

# テスト

- [x] 単体テスト追加／更新
- [x] 統合テスト追加／更新（既存テストでカバー、変更なし）
- [x] 既存テスト通過

---

# リスク・懸念点

- 内部リファクタリングであり、外部 API 仕様（リクエスト形式・レスポンス形式・エラーメッセージ）は変更していない
- 将来 `MimeType` を `parseDocument` 引数として直接渡す箇所が増えた場合、ハンドラ層以外でも `MimeType.from()` を介して構築する規約を守る必要がある

---

# 関連 Issue

Closes #201
Refs #199 #200

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（`MimeType.from()` で許可リスト検証）
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（既存維持）
- [x] ファイル I/O に適切なエラーハンドリングがある（該当なし）

### 設計

- [x] レイヤー違反がない（domain → application → infrastructure）
- [x] 既存パターンとの一貫性を保っている（ADR-0009 の方針に従う）

### 変更範囲

- [x] PR が1つの目的に絞られている（DDD 用語整理 + 値オブジェクト導入）
- [x] 不要な依存パッケージを追加していない
