### PR TITLE
chore(deps): Dependabot を security update のみに絞る

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/packages/functions"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore(deps)"
 
@@ -11,6 +12,7 @@ updates:
     directory: "/packages/web"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore(deps)"
 
@@ -18,6 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore(deps)"
 
@@ -25,5 +28,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
# 概要

Dependabot の運用方針を「security update のみ受け取る」に変更。`.github/dependabot.yml` の各 ecosystem に `open-pull-requests-limit: 0` を追加し、通常の version update PR を停止する。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [x] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `.github/dependabot.yml` の 4 エントリ（npm × functions / web / root、github-actions）すべてに `open-pull-requests-limit: 0` を追加

---

# 変更理由（Why）

- npm エコシステムでサプライチェーン攻撃（axios 等）が発生しており、新バージョンを取り込むことで悪意のコードを引き込むリスクが顕在化
- 「最新追従」よりも「既知脆弱性のみ対応」を優先する方針に切り替える
- `open-pull-requests-limit: 0` を指定すると **通常の version update PR は止まるが、security advisory ベースの PR は引き続き作成される**（GitHub 公式仕様）
- 最新追従が必要になった場合は手動で `npm update <package>` を行い、対象を限定して PR にする運用に移行する

---

# 影響範囲（Impact）

- Backend: なし
- Infra: GitHub の Dependabot 動作のみ変更
  - 通常の version update PR が来なくなる
  - security advisory ベースの PR は引き続き来る

---

# 動作確認

## 確認観点

- [ ] 正常系
- [ ] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. PR マージ後、Dependabot が version update PR を作成しないことを確認（次回スケジュール時）
2. もし期間内に CVE が公開されたパッケージがあれば、security advisory PR が来ることを確認

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過（コード変更なし）

---

# リスク・懸念点

- 最新追従が止まるため、エコシステム互換性の問題（peerDependencies の不整合等）が遅れて顕在化する可能性
  - 対策: 月次で `npm audit` と `npm outdated` を確認する運用に移行
- 既存の open Dependabot PR (13 本) はこの設定変更後も自動クローズされない
  - 別途手動で整理する（major のみ Issue 化、他はクローズ予定）

---

# 関連 Issue

Closes #203

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（該当なし）
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（該当なし）
- [x] ファイル I/O に適切なエラーハンドリングがある（該当なし）

### 設計

- [x] レイヤー違反がない（該当なし、設定ファイルのみ）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない
