### PR TITLE
chore(ci): 月次 npm audit ワークフローを追加する

### DIFF
--- a/.github/workflows/npm-audit-monthly.yml
+++ b/.github/workflows/npm-audit-monthly.yml
@@ -1,0 +1,76 @@
+name: npm audit (monthly)
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Run npm audit
+        id: audit
+        run: |
+          set +e
+          REPORT="audit-report.md"
+          HAS_VULN=0
+
+          for pkg in functions web; do
+            echo "## packages/${pkg}" >> "$REPORT"
+            echo "" >> "$REPORT"
+            echo '```' >> "$REPORT"
+            (cd "packages/${pkg}" && npm audit --audit-level=high) >> "$REPORT" 2>&1
+            EXIT_CODE=$?
+            echo '```' >> "$REPORT"
+            echo "" >> "$REPORT"
+
+            if [ "$EXIT_CODE" -ne 0 ]; then
+              HAS_VULN=1
+            fi
+          done
+
+          echo "has_vuln=${HAS_VULN}" >> "$GITHUB_OUTPUT"
+
+      - name: Create issue if vulnerabilities found
+        if: steps.audit.outputs.has_vuln == '1'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('audit-report.md', 'utf-8');
+            const month = new Date().toISOString().slice(0, 7);
+
+            const body = [
+              '## 概要',
+              '',
+              `${month} の月次 npm audit で high 以上の脆弱性が検出されました。`,
+              '',
+              '## 検出結果',
+              '',
+              report,
+              '## 対応',
+              '',
+              '- 各脆弱性の影響範囲を確認',
+              '- 必要なら `npm update <package>` または `npm audit fix` で対応',
+              '- 対応 PR は別途作成',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `chore(deps): npm audit 結果 (${month})`,
+              body,
+              labels: ['dependencies'],
+            });


### PR DESCRIPTION
# 概要

月次で `npm audit` を自動実行し、high 以上の脆弱性が検出されたら Issue を自動作成する GitHub Actions ワークフローを追加。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [x] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `.github/workflows/npm-audit-monthly.yml` を新規追加
  - `schedule: cron: "0 0 1 * *"` 毎月 1 日 00:00 UTC（JST 9:00）に自動実行
  - `workflow_dispatch` で手動実行も可能
  - `permissions: contents: read, issues: write`
  - `packages/functions` と `packages/web` の両方を `npm audit --audit-level=high` でチェック
  - 検出時のみ `actions/github-script@v7` で Issue を作成（label: `dependencies`）
  - 検出ゼロなら何もしない（ノイズ防止）

---

# 変更理由（Why）

- Dependabot を security update のみに絞った（#204）ことで通常の version update は止まった
- Dependabot の security PR は便利だが取りこぼしリスクがある（GitHub Advisory Database 未登録、transitive 依存深部、GitHub 側障害など）
- 「Dependabot で受け身、月次で能動的に確認」の二段構えで安全性を担保
- 本リポジトリは public のため GitHub Actions の実行コストはゼロ

---

# 影響範囲（Impact）

- Backend: なし
- Infra: GitHub Actions のジョブが 1 つ追加される（月 1 回 + 手動実行）

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. PR マージ後、GitHub Actions の `npm audit (monthly)` ワークフローが workflow_dispatch から手動実行できることを確認
2. 手動実行して、現状の脆弱性検出結果を確認
   - 検出ゼロなら Issue は作成されない
   - 検出ありなら `chore(deps): npm audit 結果 (YYYY-MM)` というタイトルの Issue が作成される
3. 翌月 1 日に schedule 実行されることを確認

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過（コード変更なし）

---

# リスク・懸念点

- workflow が誤作動した場合に Issue が大量に作成される可能性 → high 以上のみ条件で絞っているのでリスク低
- 既知の高 severity 脆弱性が長期間放置されると、毎月同じ内容の Issue が積み上がる
  - 対応: 該当 Issue を都度クローズするか、対応 PR を作成する運用とする
- `actions/github-script@v7` の `github.rest.issues.create` 失敗時はワークフロー全体が失敗扱いになる（再実行で復旧可能）

---

# 関連 Issue

Closes #207
Refs #204

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（該当なし）
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（github-script 内部の rest 呼び出し）
- [x] ファイル I/O に適切なエラーハンドリングがある（audit-report.md 書き込みのみ、CI 環境内）

### 設計

- [x] レイヤー違反がない（該当なし）
- [x] 既存パターンとの一貫性を保っている（既存 ci.yml の actions/checkout@v6, setup-node@v6 を踏襲）

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない
