### PR TITLE
fix: gemini / document-ai ハンドラの領収書 PII ログを除去する

### DIFF
--- a/packages/functions/src/handlers/parse-document-gemini.ts
+++ b/packages/functions/src/handlers/parse-document-gemini.ts
@@ -48,13 +48,16 @@ export const handleParseDocumentGemini = async (req: Request, res: JsonResponse)
       extractor,
     );
 
+    // 領収書は店名・金額・登録番号など PII/取引情報を含むため、値そのものは
+    // ログに出さない。抽出可否（デバッグに有用）と source のみを記録する。
     console.log(
-      `[AI] receipt:`,
+      `[AI] receipt extracted`,
       JSON.stringify({
-        supplierName: receipt.supplierName,
-        receiptDate: receipt.receiptDate,
-        totalAmount: receipt.totalAmount,
-        registrationNumber: receipt.registrationNumber,
+        source: receipt.meta?.source,
+        hasSupplierName: receipt.supplierName !== null,
+        hasReceiptDate: receipt.receiptDate !== null,
+        hasTotalAmount: receipt.totalAmount !== null,
+        hasRegistrationNumber: receipt.registrationNumber !== null,
       }),
     );
     const body = { receipt };

--- a/packages/functions/src/handlers/parse-document.ts
+++ b/packages/functions/src/handlers/parse-document.ts
@@ -48,13 +48,16 @@ export const handleParseDocument = async (req: Request, res: JsonResponse): Prom
       extractor,
     );
 
+    // 領収書は店名・金額・登録番号など PII/取引情報を含むため、値そのものは
+    // ログに出さない。抽出可否（デバッグに有用）と source のみを記録する。
     console.log(
-      `[AI] receipt:`,
+      `[AI] receipt extracted`,
       JSON.stringify({
-        supplierName: receipt.supplierName,
-        receiptDate: receipt.receiptDate,
-        totalAmount: receipt.totalAmount,
-        registrationNumber: receipt.registrationNumber,
+        source: receipt.meta?.source,
+        hasSupplierName: receipt.supplierName !== null,
+        hasReceiptDate: receipt.receiptDate !== null,
+        hasTotalAmount: receipt.totalAmount !== null,
+        hasRegistrationNumber: receipt.registrationNumber !== null,
       }),
     );
     const body = { receipt };


### PR DESCRIPTION
# 概要

`parse-document-gemini.ts` と `parse-document.ts`（Document AI）のハンドラが、抽出結果の PII（店名・金額・登録番号・日付）を `console.log` で Cloud Logging に出力していた。値ではなく **抽出可否（真偽値）と `source` のみ** を記録する形に修正する。#224 の Claude ハンドラ対応と同形式に統一。

## 種別

- [ ] bug
- [x] fix（PII/コンプライアンス）
- [ ] refactor
- [ ] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `handlers/parse-document.ts`・`handlers/parse-document-gemini.ts` の `[AI] receipt:` ログを masked 形式に変更。
  - Before: `supplierName` / `receiptDate` / `totalAmount` / `registrationNumber` の**値**を出力
  - After: `source` と `hasSupplierName` / `hasReceiptDate` / `hasTotalAmount` / `hasRegistrationNumber`（**真偽値**）のみ
- デバッグ性（どの項目が抽出できたか）は維持。レスポンス（`res.json({ receipt })`）は不変。

# 変更理由（Why）

- 領収書は店名・金額・登録番号など個人情報・取引情報を含み、Cloud Logging へ永続化すると PII/コンプライアンス上のリスクとなる。
- #224 の CodeRabbit レビューで Claude ハンドラについて顕在化したが、同一ログが gemini / document-ai ハンドラにも存在したため、横断的に統一する。

# 影響範囲（Impact）

- Backend: 2ハンドラのデバッグログのみ。抽出ロジック・レスポンス契約・API 挙動に変更なし。
- Infra: なし。

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [x] 境界値
- [x] 回帰影響なし

## 確認手順

Docker 経由で確認:

1. `build`（tsc）グリーン
2. `test`: 98 件パス（既存テストはログ内容に非依存のため回帰なし）
3. `lint` / `format:check` グリーン
4. 独立レビュー: `meta?.source` の安全性・レスポンス不変・PII 残存なし・テスト非依存・2ファイル一貫性 を確認済み

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過

（ログ出力の変更のみで新規テストは不要。既存ハンドラテストはログ内容を検証していないため回帰なし）

---

# リスク・懸念点

- なし（デバッグログの伏字化のみ・ロジック非変更）。
- `taxAmount` は元ログにも含まれておらず、本変更でも対象外で従前どおり。

# 関連 Issue

Closes #225
Refs #224

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除（PII 値を除去）
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（変更なし・既存共有）
- [x] シークレットや API キーをハードコードしていない
- [x] PII を Cloud Logging に永続化しない（本 PR の目的）

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（変更なし）
- [x] ファイル I/O に適切なエラーハンドリングがある（該当なし）

### 設計

- [x] レイヤー違反がない
- [x] 既存パターンとの一貫性を保っている（Claude ハンドラと同形式）

### 変更範囲

- [x] PR が1つの目的に絞られている（PII ログ除去）
- [x] 不要な依存パッケージを追加していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
