### PR TITLE
refactor: inbound 認証キー API_KEY を FUNCTIONS_API_KEY にリネームする

### DIFF
--- a/packages/functions/.env.example
+++ b/packages/functions/.env.example
@@ -19,5 +19,5 @@ CLAUDE_TIMEOUT_MS=30000
 CLAUDE_LOCATION=global
 
 # ローカル開発用（.env.local に設定）。デプロイ環境では Secret Manager で管理
-# API_KEY=your-api-key
+# FUNCTIONS_API_KEY=your-api-key
 # api 経路のみ使用。ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -112,14 +112,14 @@ Firebase Functions は[環境構成ファイル](https://firebase.google.com/doc
 | `DOCAI_LOCATION`     | Yes  | Document AI のロケーション（例: `asia-southeast1`） |
 | `DOCAI_PROCESSOR_ID` | Yes  | Document AI プロセッサ ID                           |
 
-### API_KEY の管理
+### FUNCTIONS_API_KEY の管理
 
-`parseDocumentHttp`（onRequest）は Bearer トークンによる API キー認証を行います。
+`parseDocumentHttp`（onRequest）は Bearer トークンによる呼び出し側 API キー認証を行います。
 
-- **ローカル開発**: `.env.local` に `API_KEY=<値>` を設定（エミュレータが読み込む）
+- **ローカル開発**: `.env.local` に `FUNCTIONS_API_KEY=<値>` を設定（エミュレータが読み込む）
 - **デプロイ環境**: Google Cloud Secret Manager で管理（後述）
 
-コード上は `defineSecret("API_KEY")` で宣言し、`secrets: [apiKey]` で関数に注入しています。
+コード上は `defineSecret("FUNCTIONS_API_KEY")` で宣言し、`secrets: [functionsApiKey]` で関数に注入しています。
 
 ## デプロイ
 
@@ -138,14 +138,14 @@ Firebase Functions は[環境構成ファイル](https://firebase.google.com/doc
 npm run docker:functions:sh
 
 # コンテナ内で
-firebase functions:secrets:set API_KEY --project <project-id>
+firebase functions:secrets:set FUNCTIONS_API_KEY --project <project-id>
 # プロンプトに従って値を入力
 ```
 
 設定済みのシークレットは以下で確認できます。
 
 ```bash
-firebase functions:secrets:get API_KEY --project <project-id>
+firebase functions:secrets:get FUNCTIONS_API_KEY --project <project-id>
 ```
 
 ### デプロイの実行

--- a/packages/functions/src/handlers/parse-document-claude.test.ts
+++ b/packages/functions/src/handlers/parse-document-claude.test.ts
@@ -57,7 +57,7 @@ const mockReceipt = {
 describe("handleParseDocumentClaude", () => {
   beforeEach(() => {
     mockExtract.mockReset();
-    vi.stubEnv("API_KEY", TEST_API_KEY);
+    vi.stubEnv("FUNCTIONS_API_KEY", TEST_API_KEY);
   });
 
   afterEach(() => {

--- a/packages/functions/src/handlers/parse-document-claude.ts
+++ b/packages/functions/src/handlers/parse-document-claude.ts
@@ -20,7 +20,7 @@ export const handleParseDocumentClaude = async (req: Request, res: JsonResponse)
     return;
   }
 
-  const authResult = validateApiKey(req.headers.authorization, process.env.API_KEY ?? "");
+  const authResult = validateApiKey(req.headers.authorization, process.env.FUNCTIONS_API_KEY ?? "");
   if (!authResult.ok) {
     const body = { error: authResult.message };
     console.log(`[RES] 401`, JSON.stringify(body));

--- a/packages/functions/src/handlers/parse-document-gemini.test.ts
+++ b/packages/functions/src/handlers/parse-document-gemini.test.ts
@@ -57,7 +57,7 @@ const mockReceipt = {
 describe("handleParseDocumentGemini", () => {
   beforeEach(() => {
     mockExtract.mockReset();
-    vi.stubEnv("API_KEY", TEST_API_KEY);
+    vi.stubEnv("FUNCTIONS_API_KEY", TEST_API_KEY);
   });
 
   afterEach(() => {

--- a/packages/functions/src/handlers/parse-document-gemini.ts
+++ b/packages/functions/src/handlers/parse-document-gemini.ts
@@ -20,7 +20,7 @@ export const handleParseDocumentGemini = async (req: Request, res: JsonResponse)
     return;
   }
 
-  const authResult = validateApiKey(req.headers.authorization, process.env.API_KEY ?? "");
+  const authResult = validateApiKey(req.headers.authorization, process.env.FUNCTIONS_API_KEY ?? "");
   if (!authResult.ok) {
     const body = { error: authResult.message };
     console.log(`[RES] 401`, JSON.stringify(body));

--- a/packages/functions/src/handlers/parse-document.test.ts
+++ b/packages/functions/src/handlers/parse-document.test.ts
@@ -56,7 +56,7 @@ const mockReceipt = {
 describe("handleParseDocument", () => {
   beforeEach(() => {
     mockExtract.mockReset();
-    vi.stubEnv("API_KEY", TEST_API_KEY);
+    vi.stubEnv("FUNCTIONS_API_KEY", TEST_API_KEY);
   });
 
   afterEach(() => {

--- a/packages/functions/src/handlers/parse-document.ts
+++ b/packages/functions/src/handlers/parse-document.ts
@@ -20,7 +20,7 @@ export const handleParseDocument = async (req: Request, res: JsonResponse): Prom
     return;
   }
 
-  const authResult = validateApiKey(req.headers.authorization, process.env.API_KEY ?? "");
+  const authResult = validateApiKey(req.headers.authorization, process.env.FUNCTIONS_API_KEY ?? "");
   if (!authResult.ok) {
     const body = { error: authResult.message };
     console.log(`[RES] 401`, JSON.stringify(body));

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -7,7 +7,7 @@ import { handleParseDocumentGemini } from "./handlers/parse-document-gemini.js";
 import { handleParseDocumentClaudeCall } from "./handlers/parse-document-claude-call.js";
 import { handleParseDocumentClaude } from "./handlers/parse-document-claude.js";
 
-const apiKey = defineSecret("API_KEY");
+const functionsApiKey = defineSecret("FUNCTIONS_API_KEY");
 // Claude 直接 API 経路（CLAUDE_TRANSPORT=api）用。vertex 経路では未使用（ADR-0013）。
 const anthropicApiKey = defineSecret("ANTHROPIC_API_KEY");
 
@@ -16,7 +16,7 @@ export const parseDocumentCall = onCall({ region: "asia-northeast1" }, handlePar
 
 /** 外部サービス用 — onRequest + API キー認証 */
 export const parseDocumentHttp = onRequest(
-  { region: "asia-northeast1", secrets: [apiKey] },
+  { region: "asia-northeast1", secrets: [functionsApiKey] },
   handleParseDocument,
 );
 
@@ -28,7 +28,7 @@ export const parseDocumentGeminiCall = onCall(
 
 /** 外部サービス用 — Gemini onRequest + API キー認証 */
 export const parseDocumentGeminiHttp = onRequest(
-  { region: "asia-northeast1", secrets: [apiKey] },
+  { region: "asia-northeast1", secrets: [functionsApiKey] },
   handleParseDocumentGemini,
 );
 
@@ -40,6 +40,6 @@ export const parseDocumentClaudeCall = onCall(
 
 /** 外部サービス用 — Claude onRequest + 呼び出し側 API キー認証（+ api 経路は ANTHROPIC_API_KEY） */
 export const parseDocumentClaudeHttp = onRequest(
-  { region: "asia-northeast1", secrets: [apiKey, anthropicApiKey] },
+  { region: "asia-northeast1", secrets: [functionsApiKey, anthropicApiKey] },
   handleParseDocumentClaude,
 );

--- a/packages/functions/src/infrastructure/auth-validator.test.ts
+++ b/packages/functions/src/infrastructure/auth-validator.test.ts
@@ -18,7 +18,8 @@ describe("validateApiKey", () => {
     const result = validateApiKey("Basic abc123", validKey);
     expect(result).toEqual({
       ok: false,
-      message: "Authorization ヘッダーの形式が不正です。Bearer <API_KEY> を使用してください。",
+      message:
+        "Authorization ヘッダーの形式が不正です。Bearer <FUNCTIONS_API_KEY> を使用してください。",
     });
   });
 

--- a/packages/functions/src/infrastructure/auth-validator.ts
+++ b/packages/functions/src/infrastructure/auth-validator.ts
@@ -22,7 +22,8 @@ export function validateApiKey(
   if (!authorizationHeader.startsWith("Bearer ")) {
     return {
       ok: false,
-      message: "Authorization ヘッダーの形式が不正です。Bearer <API_KEY> を使用してください。",
+      message:
+        "Authorization ヘッダーの形式が不正です。Bearer <FUNCTIONS_API_KEY> を使用してください。",
     };
   }
 

--- a/packages/functions/tests/integration/handlers/parse-document-claude.test.ts
+++ b/packages/functions/tests/integration/handlers/parse-document-claude.test.ts
@@ -15,7 +15,7 @@ describe("handleParseDocumentClaude（結合テスト）", () => {
     vi.stubEnv("CLAUDE_TRANSPORT", TEST_ENV.CLAUDE_TRANSPORT);
     vi.stubEnv("ANTHROPIC_API_KEY", TEST_ENV.ANTHROPIC_API_KEY);
     vi.stubEnv("CLAUDE_MODEL", TEST_ENV.CLAUDE_MODEL);
-    vi.stubEnv("API_KEY", TEST_ENV.API_KEY);
+    vi.stubEnv("FUNCTIONS_API_KEY", TEST_ENV.FUNCTIONS_API_KEY);
   });
 
   afterEach(() => {
@@ -26,7 +26,7 @@ describe("handleParseDocumentClaude（結合テスト）", () => {
     mockMessagesCreate.mockResolvedValue(MOCK_CLAUDE_RESPONSE);
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocumentClaude(req, res);
 
@@ -45,7 +45,7 @@ describe("handleParseDocumentClaude（結合テスト）", () => {
   it("バリデーションエラー: サポート外の mimeType で 400 を返す", async () => {
     const { req, res } = createMockReqRes({
       body: { content: "base64data", mimeType: "text/plain" },
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocumentClaude(req, res);
 
@@ -57,7 +57,7 @@ describe("handleParseDocumentClaude（結合テスト）", () => {
     mockMessagesCreate.mockRejectedValue(new Error("Vertex unavailable"));
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocumentClaude(req, res);
 
@@ -69,7 +69,7 @@ describe("handleParseDocumentClaude（結合テスト）", () => {
     vi.stubEnv("ANTHROPIC_API_KEY", "");
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocumentClaude(req, res);
 

--- a/packages/functions/tests/integration/handlers/parse-document-gemini.test.ts
+++ b/packages/functions/tests/integration/handlers/parse-document-gemini.test.ts
@@ -14,7 +14,7 @@ describe("handleParseDocumentGemini（結合テスト）", () => {
     vi.stubEnv("GCP_PROJECT_ID", TEST_ENV.GCP_PROJECT_ID);
     vi.stubEnv("GEMINI_LOCATION", TEST_ENV.GEMINI_LOCATION);
     vi.stubEnv("GEMINI_MODEL", TEST_ENV.GEMINI_MODEL);
-    vi.stubEnv("API_KEY", TEST_ENV.API_KEY);
+    vi.stubEnv("FUNCTIONS_API_KEY", TEST_ENV.FUNCTIONS_API_KEY);
   });
 
   afterEach(() => {
@@ -25,7 +25,7 @@ describe("handleParseDocumentGemini（結合テスト）", () => {
     mockGenerateContent.mockResolvedValue(MOCK_GEMINI_RESPONSE);
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocumentGemini(req, res);
 
@@ -44,7 +44,7 @@ describe("handleParseDocumentGemini（結合テスト）", () => {
   it("バリデーションエラー: サポート外の mimeType で 400 を返す", async () => {
     const { req, res } = createMockReqRes({
       body: { content: "base64data", mimeType: "text/plain" },
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocumentGemini(req, res);
 
@@ -56,7 +56,7 @@ describe("handleParseDocumentGemini（結合テスト）", () => {
     mockGenerateContent.mockRejectedValue(new Error("Vertex unavailable"));
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocumentGemini(req, res);
 
@@ -68,7 +68,7 @@ describe("handleParseDocumentGemini（結合テスト）", () => {
     vi.stubEnv("GCP_PROJECT_ID", "");
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocumentGemini(req, res);
 

--- a/packages/functions/tests/integration/handlers/parse-document.test.ts
+++ b/packages/functions/tests/integration/handlers/parse-document.test.ts
@@ -16,7 +16,7 @@ describe("handleParseDocument（結合テスト）", () => {
     vi.stubEnv("GCP_PROJECT_ID", TEST_ENV.GCP_PROJECT_ID);
     vi.stubEnv("DOCAI_LOCATION", TEST_ENV.DOCAI_LOCATION);
     vi.stubEnv("DOCAI_PROCESSOR_ID", TEST_ENV.DOCAI_PROCESSOR_ID);
-    vi.stubEnv("API_KEY", TEST_ENV.API_KEY);
+    vi.stubEnv("FUNCTIONS_API_KEY", TEST_ENV.FUNCTIONS_API_KEY);
   });
 
   afterEach(() => {
@@ -27,7 +27,7 @@ describe("handleParseDocument（結合テスト）", () => {
     mockProcessDocument.mockResolvedValue(MOCK_SDK_RESPONSE);
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocument(req, res);
 
@@ -56,7 +56,7 @@ describe("handleParseDocument（結合テスト）", () => {
   it("バリデーションエラー: サポート外の mimeType で 400 を返す", async () => {
     const { req, res } = createMockReqRes({
       body: { content: "base64data", mimeType: "text/plain" },
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocument(req, res);
 
@@ -68,7 +68,7 @@ describe("handleParseDocument（結合テスト）", () => {
     mockProcessDocument.mockRejectedValue(new Error("Document AI unavailable"));
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocument(req, res);
 
@@ -82,7 +82,7 @@ describe("handleParseDocument（結合テスト）", () => {
     vi.stubEnv("DOCAI_PROCESSOR_ID", "");
 
     const { req, res } = createMockReqRes({
-      headers: { authorization: `Bearer ${TEST_ENV.API_KEY}` },
+      headers: { authorization: `Bearer ${TEST_ENV.FUNCTIONS_API_KEY}` },
     });
     await handleParseDocument(req, res);
 

--- a/packages/functions/tests/integration/helpers/fixtures.ts
+++ b/packages/functions/tests/integration/helpers/fixtures.ts
@@ -12,7 +12,7 @@ export const TEST_ENV = {
   CLAUDE_MODEL: "claude-opus-4-8",
   CLAUDE_LOCATION: "global",
   ANTHROPIC_API_KEY: "sk-ant-test",
-  API_KEY: "test-api-key-12345",
+  FUNCTIONS_API_KEY: "test-api-key-12345",
 } as const;
 
 export const EXPECTED_PROCESSOR_NAME = `projects/${TEST_ENV.GCP_PROJECT_ID}/locations/${TEST_ENV.DOCAI_LOCATION}/processors/${TEST_ENV.DOCAI_PROCESSOR_ID}`;


### PR DESCRIPTION
# 概要

HTTP エンドポイント（`parseDocumentHttp` / `...GeminiHttp` / `...ClaudeHttp`）の**呼び出し側認証キー** `API_KEY` を、何の API のキーか分かる **`FUNCTIONS_API_KEY`** にリネームする。outbound の `ANTHROPIC_API_KEY`（#227）と名前で区別する。

env 変数名 / Secret 名 / エラーメッセージのみの変更で、**外部呼び出し元が送る `Authorization: Bearer <値>` は不変**（クライアント側は無影響）。

## 種別

- [ ] bug
- [ ] feature
- [x] refactor
- [ ] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `index.ts`: `defineSecret("FUNCTIONS_API_KEY")`、変数 `functionsApiKey`、`secrets` 配列。
- 3ハンドラ（`parse-document.ts` / `-gemini.ts` / `-claude.ts`）: `process.env.FUNCTIONS_API_KEY`。
- `auth-validator.ts`: メッセージ `Bearer <FUNCTIONS_API_KEY>`。
- `.env.example` / `README.md`（ローカル `.env.local` 手順・Secret Manager set/get 手順）。
- テスト: `fixtures.ts`（`TEST_ENV.FUNCTIONS_API_KEY`）・`stubEnv`・auth-validator の期待値。
- ※ `ANTHROPIC_API_KEY`（別物・outbound）、`config.apiKey`（Anthropic SDK の api キー）、テストの値 `test-api-key-12345` は非対象で不変。

# 変更理由（Why）

`API_KEY` は名前から何の API のキーか分からず、outbound の `ANTHROPIC_API_KEY` を追加した今は特に紛らわしい。inbound（我々が発行し呼び出し元が提示）と outbound を名前で明確化する（#227 レビュー中の指摘）。

# 影響範囲（Impact）

- Backend: env/Secret 名とメッセージのみ。認証ロジック・レスポンス契約・HTTP 契約（Authorization ヘッダ値）は不変。
- Web: 影響なし（onCall 利用で inbound キー非依存。`VITE_FIREBASE_API_KEY` は別物）。
- Infra: **デプロイ移行が必要**（下記）。

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [x] 境界値
- [x] 回帰影響なし

## 確認手順

Docker 経由: build（tsc）/ test **139 件** / lint / format / coverage 99.28%（閾値クリア）すべて green。独立レビューで取りこぼし・`ANTHROPIC_API_KEY` 誤爆なしを確認（README の旧参照も本 PR で修正）。

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過（キー名の更新のみ・新規テストは不要）

---

# リスク・懸念点

- **移行が必要（破壊的・要手動）**:
  - ローカル: `.env.local` / `.env` / `.env.<project>` の `API_KEY` を `FUNCTIONS_API_KEY` にリネーム。
  - デプロイ: Secret Manager に `FUNCTIONS_API_KEY` を作成 → デプロイ → 旧 `API_KEY` を削除（`firebase functions:secrets:set/destroy`）。設定しないと HTTP が 401 になる。
- 外部呼び出し元の Authorization ヘッダ値は不変のためクライアント改修は不要。

# 関連 Issue

Closes #230
Refs #227

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（変更なし）
- [x] シークレットや API キーをハードコードしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（変更なし）
- [x] ファイル I/O に適切なエラーハンドリングがある（該当なし）

### 設計

- [x] レイヤー違反がない
- [x] 既存パターンとの一貫性を保っている（命名の明確化のみ）

### 変更範囲

- [x] PR が1つの目的に絞られている（リネーム）
- [x] 不要な依存パッケージを追加していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
