### PR TITLE
docs: README に ANTHROPIC_API_KEY のデプロイ手順を追記する

### DIFF
--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -121,6 +121,18 @@ Firebase Functions は[環境構成ファイル](https://firebase.google.com/doc
 
 コード上は `defineSecret("FUNCTIONS_API_KEY")` で宣言し、`secrets: [functionsApiKey]` で関数に注入しています。
 
+### Claude 認証（ANTHROPIC_API_KEY / CLAUDE_TRANSPORT）
+
+`parseDocumentClaude*` は Claude の呼び出し経路を `CLAUDE_TRANSPORT` で切り替えます（ADR-0013）。
+
+- `CLAUDE_TRANSPORT=api`（既定）: Anthropic 直接 API。`ANTHROPIC_API_KEY` を使用。
+- `CLAUDE_TRANSPORT=vertex`: Vertex AI 経由（ADC 認証）。`ANTHROPIC_API_KEY` は未使用。
+
+- **ローカル開発**: api 経路を試す場合、`.env.local` に `ANTHROPIC_API_KEY=<値>` を設定（エミュレータが読み込む）。
+- **デプロイ環境**: Google Cloud Secret Manager で管理（後述）。
+
+コード上は `defineSecret("ANTHROPIC_API_KEY")` で Claude 関数に宣言しています。**この宣言は `CLAUDE_TRANSPORT` の値に関わらず有効なため、`vertex` 運用でも Secret Manager に `ANTHROPIC_API_KEY`（ダミー値可）が存在しないとデプロイに失敗します。**
+
 ## デプロイ
 
 デプロイ前に以下の準備が必要です：
@@ -132,13 +144,17 @@ Firebase Functions は[環境構成ファイル](https://firebase.google.com/doc
 
 ### Secret Manager のセットアップ
 
-`parseDocumentHttp` は API キーを Secret Manager から取得します。初回デプロイ前にシークレットを設定してください。
+HTTP 関数は API キーを Secret Manager から取得します。初回デプロイ前に**両方**のシークレットを設定してください。
+
+- `FUNCTIONS_API_KEY`: HTTP エンドポイント（`parseDocument*Http`）の呼び出し側認証キー。
+- `ANTHROPIC_API_KEY`: Claude 直接 API 経路用。Claude 関数に `defineSecret` 宣言があるため、`CLAUDE_TRANSPORT=vertex` 運用でも設定が必要（ダミー値可。未設定だとデプロイに失敗）。
 
 ```bash
 npm run docker:functions:sh
 
 # コンテナ内で
 firebase functions:secrets:set FUNCTIONS_API_KEY --project <project-id>
+firebase functions:secrets:set ANTHROPIC_API_KEY --project <project-id>
 # プロンプトに従って値を入力
 ```
 


### PR DESCRIPTION
# 概要

`packages/functions/README.md` の Secret Manager 手順に `ANTHROPIC_API_KEY` の記載が無かった。#227（PR #229）で `defineSecret("ANTHROPIC_API_KEY")` を Claude 関数へ宣言済みのため、README 通りに `FUNCTIONS_API_KEY` だけ設定してデプロイすると secret 未作成で `firebase deploy` が失敗する。その手順を追記する。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [ ] chore
- [x] docs
- [ ] test

---

# 変更内容（What）

- 「Claude 認証（ANTHROPIC_API_KEY / CLAUDE_TRANSPORT）」節を追加（api/vertex 切替の説明、ローカル `.env.local`、vertex 運用でもダミー設定が要る旨）。
- 「Secret Manager のセットアップ」に `ANTHROPIC_API_KEY` の `firebase functions:secrets:set` を追加し、両シークレット必須を明記。

# 変更理由（Why）

#229 のドキュメント欠落によりデプロイが破綻するのを防ぐ。ADR-0013 参照。

# 影響範囲（Impact）

- ドキュメントのみ（`packages/functions/README.md`）。コード・設定に変更なし。

---

# 動作確認

## 確認観点

- [ ] 正常系
- [ ] 異常系
- [ ] 境界値
- [ ] 回帰影響なし

（ドキュメントのみのため対象外）

---

# テスト

- [x] 既存テスト通過（ドキュメントのみ・非対象）

---

# リスク・懸念点

- なし（ドキュメント追記のみ）。

# 関連 Issue

Closes #235
Refs #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)