### PR TITLE
docs: README のコマンド一覧・技術スタック・エンジン記述の漏れを補完する

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@
 
 GitHub Actions（`.github/workflows/ci.yml`）で以下を自動実行します。
 
-各パッケージ（`cli`, `functions`, `web`）に対して matrix で並列実行:
+各パッケージ（`functions`, `web`）に対して matrix で並列実行:
 
 - `npm run lint` — ESLint
 - `npm run format:check` — Prettier

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ DDD（ドメイン駆動設計）に基づく 3 層構成を採用していま�
 | @google/genai            | ^2.10                              |
 | @anthropic-ai/vertex-sdk | ^0.19                              |
 | @anthropic-ai/sdk        | ^0.110                             |
+| firebase                 | ^12.11                             |
 | firebase-functions       | ^6.3                               |
 | firebase-admin           | ^13.4                              |
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ Google Cloud Document AI・Vertex AI Gemini・Claude（Anthropic）を抽出エ�
 
 ## 必要なもの
 
+共通:
+
 - Docker / Docker Compose
-- GCP プロジェクト（Document AI API が有効化済み）
-- Document AI プロセッサ（Expense Parser 等）
-- サービスアカウントキー（JSON）
+- GCP プロジェクトとサービスアカウントキー（JSON）— GCP 認証（ADC）に使用
 - Firebase CLI（`npm install -g firebase-tools`）— Functions のデプロイ時に必要
+
+抽出エンジンごとの前提（設定変数は `packages/functions/.env.example` 参照）:
+
+- **Document AI**（既定・Web が使用）: Document AI API の有効化、プロセッサ（Expense Parser 等）
+- **Vertex AI Gemini**（任意 / `parseDocumentGemini*`）: Vertex AI API の有効化（認証はサービスアカウントの ADC を流用。ADR-0010）
+- **Claude**（任意 / `parseDocumentClaude*`）: 直接 API（`CLAUDE_TRANSPORT=api`・既定）は Anthropic API キー（`ANTHROPIC_API_KEY`）、Vertex 経由（`CLAUDE_TRANSPORT=vertex`）は Vertex AI 上での Claude 有効化（ADR-0012 / 0013）
 
 ## セットアップ
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # OCR Sample
 
-Google Cloud Document AI を使用してレシート等の画像・PDF から情報を抽出する OCR ツールです。
+Google Cloud Document AI・Vertex AI Gemini・Claude（Anthropic）を抽出エンジンに使い、レシート等の画像・PDF から情報を抽出する OCR ツールです。
 モノレポ構成を採用しており、デプロイ単位ごとにパッケージを分離しています。各パッケージは独立した `node_modules` と `package-lock.json` を持ちます。
 
 ## モノレポ構成
 
-| パッケージ                                  | 説明                                                  |
-| ------------------------------------------- | ----------------------------------------------------- |
-| [`packages/functions`](packages/functions/) | Firebase Functions HTTP API（Document AI による OCR） |
-| [`packages/web`](packages/web/)             | Web フロントエンド（React + Vite SPA）                |
+| パッケージ                                  | 説明                                                                    |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| [`packages/functions`](packages/functions/) | Firebase Functions HTTP API（Document AI / Gemini / Claude による OCR） |
+| [`packages/web`](packages/web/)             | Web フロントエンド（React + Vite SPA）                                  |
 
 ## 必要なもの
 
@@ -70,7 +70,7 @@ DDD（ドメイン駆動設計）に基づく 3 層構成を採用していま�
 | **ハンドラ層**         | `packages/functions/src/handlers/`       | HTTP リクエスト処理                                          |
 | **ドメイン層**         | `packages/functions/src/domain/`         | 純粋なビジネスロジック（外部依存なし）                       |
 | **アプリケーション層** | `packages/functions/src/application/`    | ユースケースの実行。インターフェースを通じてインフラ層に依存 |
-| **インフラ層**         | `packages/functions/src/infrastructure/` | 外部サービス連携（GCP Document AI・環境変数）                |
+| **インフラ層**         | `packages/functions/src/infrastructure/` | 外部サービス連携（Document AI / Gemini / Claude・環境変数）  |
 
 エントリーポイント（`packages/functions/src/index.ts`）は Cloud Functions の関数登録のみを行い、具体的なロジックは持ちません。
 
@@ -156,6 +156,9 @@ DDD（ドメイン駆動設計）に基づく 3 層構成を採用していま�
 | Playwright               | ^1.52                              |
 | Vite                     | ^8.0                               |
 | @google-cloud/documentai | ^9.5.0                             |
+| @google/genai            | ^2.10                              |
+| @anthropic-ai/vertex-sdk | ^0.19                              |
+| @anthropic-ai/sdk        | ^0.110                             |
 | firebase-functions       | ^6.3                               |
 | firebase-admin           | ^13.4                              |
 

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -1,6 +1,6 @@
 # @docai/functions
 
-Document AI を使用した OCR 機能を Firebase Functions HTTP API として提供するパッケージです。
+Document AI / Vertex AI Gemini / Claude（Anthropic）による OCR 機能を Firebase Functions HTTP API として提供するパッケージです。
 
 ## 開発コマンド
 

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -46,6 +46,18 @@ npm run test:watch       # テスト実行（ウォッチモード）
 
 結合テストのヘルパー（フィクスチャ・モック）は `tests/integration/helpers/` にまとめています。
 
+## エンドポイント
+
+3 つの抽出エンジン × onCall / onRequest の 6 関数を提供します（`src/index.ts`）。onCall は Hosting/Web 用（ADC 認証）、onRequest は外部サービス用（`FUNCTIONS_API_KEY` による Bearer 認証）。
+
+| エンジン                  | onCall（Web/ADC）         | onRequest（外部/API キー） |
+| ------------------------- | ------------------------- | -------------------------- |
+| Document AI（ADR-0002）   | `parseDocumentCall`       | `parseDocumentHttp`        |
+| Gemini（ADR-0010）        | `parseDocumentGeminiCall` | `parseDocumentGeminiHttp`  |
+| Claude（ADR-0012 / 0013） | `parseDocumentClaudeCall` | `parseDocumentClaudeHttp`  |
+
+レスポンスは Gemini / Claude が正準モデル `{ receipt: ReceiptExtraction }`（ADR-0011）、Document AI が `{ entities: ... }`。Claude の呼び出し経路は `CLAUDE_TRANSPORT`（api/vertex）で切り替えます（ADR-0013）。
+
 ## ローカル実行
 
 Docker コンテナ内で Firebase Emulator を使用してローカル実行します。
@@ -57,8 +69,8 @@ npm run docker:functions:start
 起動すると以下のようなログが表示されます：
 
 ```text
-✔  functions[<region>-parseDocument]: http function initialized
-    (http://127.0.0.1:8080/<project-id>/<region>/parseDocument)
+✔  functions[<region>-parseDocumentHttp]: http function initialized
+    (http://127.0.0.1:8080/<project-id>/<region>/parseDocumentHttp)
 ```
 
 リージョンは `onRequest` のオプションで指定した値（現在: `asia-northeast1`）です。
@@ -66,20 +78,21 @@ npm run docker:functions:start
 ### curl でリクエスト
 
 ローカルサーバーが起動したら、別ターミナルから curl でリクエストできます。
-URL は `http://localhost:8080/<project-id>/<region>/parseDocument` の形式です。
+URL は `http://localhost:8080/<project-id>/<region>/parseDocumentHttp` の形式です（Document AI 版・onRequest。Gemini は `parseDocumentGeminiHttp`、Claude は `parseDocumentClaudeHttp`）。
 
 ```bash
 # エミュレータ起動時のログに表示される URL を使用
-# 例: http://localhost:8080/your-gcp-project-id/asia-northeast1/parseDocument
-FUNCTION_URL="http://localhost:8080/your-gcp-project-id/asia-northeast1/parseDocument"
+# 例: http://localhost:8080/your-gcp-project-id/asia-northeast1/parseDocumentHttp
+FUNCTION_URL="http://localhost:8080/your-gcp-project-id/asia-northeast1/parseDocumentHttp"
 
 # リクエスト用 JSON ファイルを作成
 CONTENT=$(base64 -i input/receipt.jpg | tr -d '\n')
 printf '{"content":"%s","mimeType":"image/jpeg"}' "$CONTENT" > /tmp/request.json
 
-# curl でリクエスト（-d @ でファイルから読み込み）
+# curl でリクエスト（onRequest は FUNCTIONS_API_KEY による Bearer 認証が必要）
 curl -s -X POST "${FUNCTION_URL}" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${FUNCTIONS_API_KEY}" \
   -d @/tmp/request.json
 ```
 
@@ -89,8 +102,8 @@ curl -s -X POST "${FUNCTION_URL}" \
 npm run docker:functions:sh
 # コンテナ内で
 npm run shell
-# シェル内で関数を呼び出し
-parseDocument({method: "POST", body: {content: "base64data", mimeType: "application/pdf"}})
+# シェル内で関数を呼び出し（onRequest 版）
+parseDocumentHttp({method: "POST", body: {content: "base64data", mimeType: "application/pdf"}})
 ```
 
 ## 環境変数
@@ -113,6 +126,8 @@ Firebase Functions は[環境構成ファイル](https://firebase.google.com/doc
 | `GCP_PROJECT_ID`     | Yes  | GCP プロジェクト ID                                 |
 | `DOCAI_LOCATION`     | Yes  | Document AI のロケーション（例: `asia-southeast1`） |
 | `DOCAI_PROCESSOR_ID` | Yes  | Document AI プロセッサ ID                           |
+
+> Gemini / Claude エンジンの設定変数（`GEMINI_*` / `CLAUDE_TRANSPORT` / `CLAUDE_MODEL` / `CLAUDE_LOCATION` / `CLAUDE_TIMEOUT_MS` 等）はいずれも既定値があり任意です。詳細は `.env.example` を参照してください。
 
 ### FUNCTIONS_API_KEY の管理
 

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -6,7 +6,9 @@ Document AI を使用した OCR 機能を Firebase Functions HTTP API として�
 
 ```bash
 npm run docker:functions:lint           # ESLint 実行
+npm run docker:functions:lint:fix       # ESLint 自動修正
 npm run docker:functions:format:check   # Prettier チェック
+npm run docker:functions:format         # Prettier フォーマット
 npm run docker:functions:test           # テスト実行（全テスト）
 npm run docker:functions:test:unit     # ユニットテストのみ実行
 npm run docker:functions:test:integration  # 結合テストのみ実行

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -6,7 +6,9 @@ React + Vite による Web フロントエンドです。ファイルをアッ�
 
 ```bash
 npm run docker:web:lint                # ESLint 実行
+npm run docker:web:lint:fix            # ESLint 自動修正
 npm run docker:web:format:check        # Prettier チェック
+npm run docker:web:format              # Prettier フォーマット
 npm run docker:web:test                # テスト実行（全テスト）
 npm run docker:web:test:integration    # 結合テストのみ実行
 npm run docker:web:test:coverage       # テスト + カバレッジ計測


### PR DESCRIPTION
# 概要

Claude エンジン追加（#224/#229）と docker スクリプト追加（#234）の README 反映漏れを補完し、あわせて**独立したドキュメント監査（doc↔code 双方向）で検出した既存の誤り・漏れ**を修正する。

## 種別

- [x] docs

---

# 変更内容（What）

## コード変更の反映漏れ（当初スコープ）
- functions/web README 開発コマンド: `docker:*:lint:fix` / `docker:*:format` を追記（#234）。
- root README 技術スタック: `@google/genai` / `@anthropic-ai/vertex-sdk` / `@anthropic-ai/sdk`、およびクライアント `firebase`（^12.11）を追記。
- root / functions README 概要・構成表・インフラ層: 「Document AI 単独」を Document AI / Gemini / Claude に更新。

## 独立監査で検出した誤り・漏れ
- **functions README（誤り修正）**: ローカル実行例のエンドポイント名 `parseDocument` → `parseDocumentHttp`（`src/index.ts` に `parseDocument` は存在せず curl が 404 になっていた）。curl 例に `Authorization: Bearer ${FUNCTIONS_API_KEY}` を追加（onRequest は認証必須）。
- **functions README（漏れ補完）**: 6 エンドポイント（3エンジン × onCall/onRequest）の一覧表を新設。Gemini/Claude の HTTP エンドポイントが discoverable に。環境変数節に Gemini/Claude 任意変数への導線を追記。
- **CONTRIBUTING.md（誤り修正）**: 実在しない `cli` パッケージへの言及を削除（CI matrix は `functions`/`web` のみ）。

# 変更理由（Why）

エンジン追加・スクリプト追加でドキュメントがコードに追随できておらず、一部は curl 例が 404 になる実害があった。doc↔code 双方向の独立監査で洗い出し、ドキュメントとコードの乖離を解消する。

# 影響範囲（Impact）

- ドキュメントのみ（root / functions / web README・CONTRIBUTING）。コード・設定に変更なし。バージョン・エンドポイント名・環境変数は実コードと一致を確認済み。

---

# テスト

- [x] 既存テスト通過（ドキュメントのみ・非対象）

# リスク・懸念点

- なし（ドキュメント修正のみ）。

# 関連 Issue

Closes #237
Refs #234 #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)