### PR TITLE
feat(functions): Gemini の既定モデルを gemini-3.5-flash-lite に変更する

### DIFF
--- a/packages/functions/.env.example
+++ b/packages/functions/.env.example
@@ -4,7 +4,7 @@ DOCAI_PROCESSOR_ID=your-processor-id
 
 # Vertex AI Gemini（parseDocumentGemini* 用。GCP_PROJECT_ID は上記を流用）
 GEMINI_LOCATION=global
-GEMINI_MODEL=gemini-2.5-flash
+GEMINI_MODEL=gemini-3.5-flash-lite
 # generateContent のリクエストタイムアウト（ミリ秒。未設定時は 30000）
 GEMINI_TIMEOUT_MS=30000
 

--- a/packages/functions/src/handlers/parse-document-gemini-call.test.ts
+++ b/packages/functions/src/handlers/parse-document-gemini-call.test.ts
@@ -6,7 +6,7 @@ vi.mock("../infrastructure/config.js", () => ({
   loadGeminiConfig: () => ({
     projectId: "test-project",
     location: "global",
-    model: "gemini-2.5-flash",
+    model: "gemini-3.5-flash-lite",
     timeoutMs: 30000,
   }),
 }));

--- a/packages/functions/src/handlers/parse-document-gemini.test.ts
+++ b/packages/functions/src/handlers/parse-document-gemini.test.ts
@@ -5,7 +5,7 @@ vi.mock("../infrastructure/config.js", () => ({
   loadGeminiConfig: () => ({
     projectId: "test-project",
     location: "global",
-    model: "gemini-2.5-flash",
+    model: "gemini-3.5-flash-lite",
     timeoutMs: 30000,
   }),
 }));

--- a/packages/functions/src/infrastructure/config.test.ts
+++ b/packages/functions/src/infrastructure/config.test.ts
@@ -49,14 +49,14 @@ describe("loadGeminiConfig", () => {
   it("環境変数からGeminiConfigを構築する", () => {
     vi.stubEnv("GCP_PROJECT_ID", "my-project");
     vi.stubEnv("GEMINI_LOCATION", "asia-northeast1");
-    vi.stubEnv("GEMINI_MODEL", "gemini-2.5-pro");
+    vi.stubEnv("GEMINI_MODEL", "gemini-3.5-flash");
     vi.stubEnv("GEMINI_TIMEOUT_MS", "15000");
 
     const config = loadGeminiConfig();
     expect(config).toEqual({
       projectId: "my-project",
       location: "asia-northeast1",
-      model: "gemini-2.5-pro",
+      model: "gemini-3.5-flash",
       timeoutMs: 15000,
     });
   });
@@ -71,7 +71,7 @@ describe("loadGeminiConfig", () => {
     expect(config).toEqual({
       projectId: "my-project",
       location: "global",
-      model: "gemini-2.5-flash",
+      model: "gemini-3.5-flash-lite",
       timeoutMs: 30000,
     });
   });

--- a/packages/functions/src/infrastructure/config.ts
+++ b/packages/functions/src/infrastructure/config.ts
@@ -30,7 +30,7 @@ export function loadGeminiConfig(): GeminiConfig {
   return {
     projectId: mustEnv("GCP_PROJECT_ID"),
     location: process.env.GEMINI_LOCATION || "global",
-    model: process.env.GEMINI_MODEL || "gemini-2.5-flash",
+    model: process.env.GEMINI_MODEL || "gemini-3.5-flash-lite",
     timeoutMs: Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 30000,
   };
 }

--- a/packages/functions/src/infrastructure/gemini-client.test.ts
+++ b/packages/functions/src/infrastructure/gemini-client.test.ts
@@ -12,7 +12,7 @@ vi.mock("@google/genai", () => ({
 const config = {
   projectId: "test-project",
   location: "global",
-  model: "gemini-2.5-flash",
+  model: "gemini-3.5-flash-lite",
   timeoutMs: 30000,
 };
 const params = { content: "base64data", mimeType: "image/jpeg" };
@@ -44,7 +44,7 @@ describe("createGeminiReceiptExtractor", () => {
     expect(result).toEqual({ ...fullReceipt, meta: { source: "gemini" } });
 
     const arg = mockGenerateContent.mock.calls[0][0];
-    expect(arg.model).toBe("gemini-2.5-flash");
+    expect(arg.model).toBe("gemini-3.5-flash-lite");
     expect(arg.contents[0].parts[0]).toEqual({
       inlineData: { mimeType: "image/jpeg", data: "base64data" },
     });

--- a/packages/functions/tests/integration/helpers/fixtures.ts
+++ b/packages/functions/tests/integration/helpers/fixtures.ts
@@ -7,7 +7,7 @@ export const TEST_ENV = {
   DOCAI_LOCATION: "us",
   DOCAI_PROCESSOR_ID: "proc-123",
   GEMINI_LOCATION: "global",
-  GEMINI_MODEL: "gemini-2.5-flash",
+  GEMINI_MODEL: "gemini-3.5-flash-lite",
   CLAUDE_TRANSPORT: "api",
   CLAUDE_MODEL: "claude-opus-4-8",
   CLAUDE_LOCATION: "global",


### PR DESCRIPTION
# 概要

ADR-0014（#241 / PR #242）の決定に従い、Gemini 抽出エンジンの既定モデルを `gemini-2.5-flash` から `gemini-3.5-flash-lite` に変更する。

`gemini-2.5-flash` は 2026-10 に廃止（ELA 入り）予定で、2027-01-28 以降は大幅値上げとなる。

## 種別

- [ ] bug
- [x] feature
- [ ] refactor
- [ ] chore
- [ ] docs
- [ ] test

---

# 変更内容（What）

- `packages/functions/src/infrastructure/config.ts`: `loadGeminiConfig()` の既定モデルを `gemini-3.5-flash-lite` に変更
- `packages/functions/.env.example`: `GEMINI_MODEL` の例示値を更新
- 既定値を検証しているテストのモデル文字列を更新
  - `src/infrastructure/config.test.ts` / `gemini-client.test.ts`
  - `src/handlers/parse-document-gemini.test.ts` / `parse-document-gemini-call.test.ts`
  - `tests/integration/helpers/fixtures.ts`
- `config.test.ts` の上書きテストで使っていた `gemini-2.5-pro` を `gemini-3.5-flash`（既定値と異なる現行モデル）に差し替え。廃止対象モデルの記述をコードベースに残さないため

`gemini-client.ts` 本体・`ReceiptExtraction` 型・正規化処理は変更していない。

---

# 変更理由（Why）

- ADR-0014 の実測比較（`input/` 5枚 × 4モデル）で、`gemini-3.5-flash-lite` は精度が現行と同点、コストは現行の 64%、レイテンシーも同等であることを確認済み
- `thinkingConfig: { thinkingBudget: 0 }` と `responseSchema` が Gemini 3 系でもそのまま動作するため、クライアント実装の変更は不要
- 最安の `gemini-3.1-flash-lite` は廃止日 2027-05-07 が設定済みのため採用しない（ADR-0014 参照）

---

# 影響範囲（Impact）

- Backend: `parseDocumentGeminiCall` / `parseDocumentGeminiHttp` が呼び出すモデルが変わる。レスポンス形状（`ReceiptExtraction`）は不変
- Infra: `GEMINI_MODEL` を明示設定しているデプロイ環境があれば更新が必要。未設定なら既定値の変更で追随する（ローカルの `.env` は `GEMINI_MODEL` 未設定のため追随する）

---

# 動作確認

## 確認観点

- [x] 正常系
- [x] 異常系
- [ ] 境界値
- [x] 回帰影響なし

## 確認手順

1. `npm run docker:functions:lint` → エラーなし
2. `npm run docker:functions:test` → 21 files / 139 tests すべてパス
3. `npm run docker:functions:build` 後、ビルド成果物から `loadGeminiConfig()` と `createGeminiReceiptExtractor()` を実際に呼び出し、`GEMINI_MODEL` 未設定の状態で既定値 `gemini-3.5-flash-lite` が使われること、および実画像 1 枚の抽出が成功することを確認（3,639ms で全項目取得。税額欄が空欄の手書き領収書のため `taxAmount` は正しく `null`）
   - ADR-0014 の互換性確認は REST 直叩きだったため、本 PR では `@google/genai` SDK 経由の本番実装パスを別途確認した
   - 検証スクリプトは領収書の個人情報を扱うためコミットせず、`tasks/` 配下にローカル保持している
4. 異常系は既存の統合テスト（設定不足・API 失敗時のエラーパス）でカバー済み

---

# テスト

- [ ] 単体テスト追加／更新
- [x] 統合テスト追加／更新
- [x] 既存テスト通過

既定値の変更に対応してテストの期待値を更新した。新規テストの追加はない（既定値は `config.test.ts` で既に検証されている）。

---

# リスク・懸念点

- 精度の裏付けはサンプル 5 枚のパイロット比較（ADR-0014）であり統計的有意性はない。ただし全候補が同点で、移行によって精度が下がる兆候は観測されていない
- `GEMINI_MODEL` を明示設定しているデプロイ環境がある場合、この PR だけでは切り替わらない
- `thinking_budget` は Gemini 3 系では旧パラメータのため、将来 `thinking_level` への置き換えが必要になる可能性がある（併用は 400 エラー。ADR-0014 に記録済み）

---

# 関連 Issue

Closes #243
Refs #241

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除
- [x] any 型を増やしていない
- [x] 80行超の関数を作っていない
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み（`grep -rn "gemini-2\.5"` で ADR 以外に残存なしを確認）

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（本 PR で変更なし）
- [x] シークレットや API キーをハードコードしていない
- [x] 領収書の個人情報をコミットしていない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（本 PR で変更なし）
- [x] ファイル I/O に適切なエラーハンドリングがある（本 PR で変更なし）

### 設計

- [x] レイヤー違反がない（変更は infrastructure 層のみ）
- [x] 既存パターンとの一貫性を保っている

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない
