### PR TITLE
docs(adr): Vertex 経路の再評価結果を ADR-0013 に記録する

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Google Cloud Document AI・Vertex AI Gemini・Claude（Anthropic）を抽出エ�
 
 - **Document AI**（既定 / `parseDocument*`）: Document AI API の有効化、プロセッサ（Expense Parser 等）
 - **Vertex AI Gemini**（`parseDocumentGemini*`）: Vertex AI API の有効化（認証はサービスアカウントの ADC を流用。ADR-0010）
-- **Claude**（`parseDocumentClaude*`）: 直接 API（`CLAUDE_TRANSPORT=api`・既定）は Anthropic API キー（`ANTHROPIC_API_KEY`）、Vertex 経由（`CLAUDE_TRANSPORT=vertex`）は Vertex AI 上での Claude 有効化（ADR-0012 / 0013）
+- **Claude**（`parseDocumentClaude*`）: 直接 API（`CLAUDE_TRANSPORT=api`・既定）は Anthropic API キー（`ANTHROPIC_API_KEY`）、Vertex 経由（`CLAUDE_TRANSPORT=vertex`）は Vertex AI 上での Claude 有効化（ADR-0012 / 0013）。なお `vertex` は組織のポリシーで構造化出力が許可されている必要があり、本プロジェクトの GCP 環境では 2026-08-14 時点で利用できません（ADR-0013「Vertex 経路の再評価」参照）
 
 ## セットアップ
 

--- a/docs/adr/0013-direct-anthropic-api-transport.md
+++ b/docs/adr/0013-direct-anthropic-api-transport.md
@@ -6,7 +6,7 @@
 
 ## コンテキスト
 
-ADR-0012 で領収書抽出エンジンとして **Vertex AI 経由の Claude** を採用した（#223 / PR #224 で実装）。しかし GCP プロジェクト `documentaisample-488504` では **Vertex 上の Claude クォータが全 base model で 0（未付与）** であり、Google への自動クォータ増申請は却下された（回答は「新規プロジェクト／請求履歴不足。48h 待って再申請、または請求履歴の蓄積が必要」）。実際に呼び出すと `HTTP 429 RESOURCE_EXHAUSTED` となり、ADR-0012 が本番適用の前提とした**サンプルによる実測比較（精度・コスト・レイテンシー）が完全にブロックされている**。
+ADR-0012 で領収書抽出エンジンとして **Vertex AI 経由の Claude** を採用した（#223 / PR #224 で実装）。しかし GCP プロジェクト `documentaisample-488504` では **Vertex 上の Claude クォータが全 base model で 0（未付与）** であり、Google への自動クォータ増申請は却下された（回答は「新規プロジェクト／請求履歴不足。48h 待って再申請、または請求履歴の蓄積が必要」）。実際に呼び出すと `HTTP 429 RESOURCE_EXHAUSTED` となり、ADR-0012 が本番適用の前提とした**サンプルによる実測比較（精度・コスト・レイテンシー）が完全にブロックされている**。（※本段落は本 ADR 執筆時点＝2026-07-06 の状況。この前提は後日変化しており、現況は後述の「Vertex 経路の再評価」を参照）
 
 当該プロジェクトは実利用が少なく請求履歴が積み上がらないため、自動申請は待っても通りにくい。Sales/サポート経由の手動申請（少量・評価用途）は並行して実施するが、承認は不確実で時期も読めない。
 
@@ -19,9 +19,9 @@ Claude の呼び出し経路として **Anthropic 直接 API を追加採用**�
 - infrastructure 層に **`CLAUDE_TRANSPORT`（`api` | `vertex`）** を追加し、`ReceiptExtractor` ポートの実装（Claude クライアント）を切り替える。**既定は `api`**（当面クォータ非依存で動作する経路を既定とする）。
   - `api`: `new Anthropic({ apiKey })`（`@anthropic-ai/sdk`）
   - `vertex`: 既存 `new AnthropicVertex({ projectId, region })`（ADR-0012）
-- **Vertex 経路は削除しない**。クォータ付与後は `CLAUDE_TRANSPORT=vertex` で GCP 統一構成（ADC・データ GCP 内完結）に戻せる。
+- **Vertex 経路は削除しない**。クォータ付与後は `CLAUDE_TRANSPORT=vertex` で GCP 統一構成（ADC・データ GCP 内完結）に戻せる。（※後述の「Vertex 経路の再評価」の通り、復帰にはクォータに加えて**組織ポリシーによる構造化出力の許可、またはコード側での代替実装**が必要であることが後日判明した）
 - 認証は **`ANTHROPIC_API_KEY`（Secret Manager 管理）**。`onRequest` の呼び出し側認証は既存 `API_KEY` を流用する。
-- モデル ID（既定 `claude-opus-4-8`）・API 仕様（`temperature`/`top_p`/`top_k` 不送出・`thinking` 省略・構造化出力 `output_config.format`）は両トランスポートで共通。
+- モデル ID（既定 `claude-opus-4-8`）・API 仕様（`temperature`/`top_p`/`top_k` 不送出・`thinking` 省略・構造化出力 `output_config.format`）は両トランスポートで共通。（※構造化出力は vertex 経路では**組織ポリシーによる明示的な許可が前提**。後述の「Vertex 経路の再評価」を参照）
 - リクエスト/レスポンス形状は `@anthropic-ai/sdk` と `@anthropic-ai/vertex-sdk` でほぼ同一（同じ `messages.create`）のため、**共有ロジック**（プロンプト・JSON Schema・コンテンツブロック生成・レスポンス解析＋`stop_reason` 処理＋正準モデルへの正規化）を抽出し、2アダプタは**クライアント生成の差分のみ**とする。
 - **エンドポイントは増やさない**。既存 `parseDocumentClaudeCall` / `parseDocumentClaudeHttp`（ADR-0012）をそのまま用い、トランスポートは設定で選ぶ。
 
@@ -31,7 +31,7 @@ ADR-0012 は廃止しない。本 ADR は ADR-0012 の「直接 API を却下」
 
 - **評価をクォータ非依存で前進できる**: 直接 API は Anthropic 側のアカウントレート上限のみに依存し、GCP クォータ与信を回避できる。ADR-0012 が前提とした PR-B 実測（精度・コスト・レイテンシー）を実際に採取できるようになる。
 - **追加コストが小さい**: 両 SDK は同一の Messages API 形状を持つため、共有ロジックを再利用でき、直接 API アダプタはクライアント生成の差分のみで済む。
-- **Vertex の利点を捨てない**: トランスポート切替にすることで、クォータ付与後に設定変更だけで GCP 統一構成（ADC・データレジデンシーが GCP 方針に載る）へ戻せる。ADR-0012 の実装（PR #224）は無駄にならない。
+- **Vertex の利点を捨てない**: トランスポート切替にすることで、クォータ付与後に設定変更だけで GCP 統一構成（ADC・データレジデンシーが GCP 方針に載る）へ戻せる。ADR-0012 の実装（PR #224）は無駄にならない。（※後述の「Vertex 経路の再評価」の通り、実際の復帰条件はクォータ付与だけでは足りず、**組織ポリシーの許可値追加、またはコード側での構造化出力の代替**が必要と後日判明した。Vertex 実装自体が無駄にならない点は変わらない）
 
 代替案として次を検討した。
 
@@ -43,7 +43,7 @@ ADR-0012 は廃止しない。本 ADR は ADR-0012 の「直接 API を却下」
 - **コスト**: 単価は Vertex と同水準（既定 `claude-opus-4-8` 入力 $5.00 / 出力 $25.00・100万トークンあたり）。従量課金は **Anthropic 側の請求**となり、GCP 請求とは別系統。1 枚あたり概算は ADR-0012 のコスト表を流用し、実測は本 ADR の検証で採取する。
 - **クォータ・レート制限**: Anthropic API の**アカウント単位のレート上限（RPM / ITPM / OTPM、利用 Tier に依存）**に従う。GCP クォータ非依存。件数増加時は Tier 引き上げ・バックオフ方針を評価する。
 - **レイテンシー**: `claude-opus-4-8` は高精度な一方、応答時間は Gemini Flash より長くなり得る（ADR-0012 と同様）。`CLAUDE_TIMEOUT_MS`（既定 30 秒）と Cloud Functions タイムアウト（gen2 既定 60 秒）の妥当性を検証で確認する。SDK の再試行（既定 maxRetries=2 でタイムアウトも再試行）は Vertex 実装同様に無効化し、関数の外側デッドライン超過とコスト増を避ける。
-- **データレジデンシー・個人情報（最重要トレードオフ）**: 領収書には店名・日付・金額・登録番号など個人情報・取引情報が含まれる。直接 API では、これらが **GCP / Vertex を経由せず Anthropic の API（主に米国リージョン）へ送信**される。Anthropic API は既定で**入力データをモデル学習に使用せず**、一定期間で削除する運用だが、**GCP 内に処理が閉じる Vertex 経路とは処理主体・データ処理条件（DPA）が異なる**。本 ADR では **評価 / POC 目的に限り許容**とする。**本番採用の前に、Anthropic のデータ処理条件・DPA の確認、個人情報保護法・契約上の要件充足、必要に応じ ZDR（ゼロデータ保持）等のオプション要否を検討する**ことを必須とする。データ所在要件が厳しい場合は `CLAUDE_TRANSPORT=vertex`（クォータ付与後）を選ぶ。
+- **データレジデンシー・個人情報（最重要トレードオフ）**: 領収書には店名・日付・金額・登録番号など個人情報・取引情報が含まれる。直接 API では、これらが **GCP / Vertex を経由せず Anthropic の API（主に米国リージョン）へ送信**される。Anthropic API は既定で**入力データをモデル学習に使用せず**、一定期間で削除する運用だが、**GCP 内に処理が閉じる Vertex 経路とは処理主体・データ処理条件（DPA）が異なる**。本 ADR では **評価 / POC 目的に限り許容**とする。**本番採用の前に、Anthropic のデータ処理条件・DPA の確認、個人情報保護法・契約上の要件充足、必要に応じ ZDR（ゼロデータ保持）等のオプション要否を検討する**ことを必須とする。データ所在要件が厳しい場合は `CLAUDE_TRANSPORT=vertex` を選ぶ。ただし後述の「Vertex 経路の再評価」の通り、この用途では **3 条件**が必要になる（2026-08-14 時点でいずれも未充足）。(1) `global` は処理リージョンを保証しないため `CLAUDE_LOCATION` にマルチリージョン／リージョン指定が必要（ADR-0012）、(2) **そのリージョンでのクォータ付与**（実測では `us-east5` は 429。クォータはリージョンごとに別枠）、(3) 組織ポリシーによる構造化出力の許可、またはコード側での代替実装。
 - **コンプライアンス・セキュリティ**: 新シークレット `ANTHROPIC_API_KEY` を **Secret Manager** で管理する（コードにハードコードしない。ローカルは `.env.local`、デプロイ環境は Functions ランタイムのサービスアカウントに Secret アクセス権を付与）。キー漏洩時のローテーション手順を運用に含める。`onRequest` の呼び出し側認証は既存 `API_KEY` を流用する。Vertex 経路と異なり `roles/aiplatform.user` は不要。
 - **受容リスク（本 ADR のスコープであえて対応しないと決めた事項）**:
   - Anthropic のデータ処理条件の詳細確認・DPA 締結は本 ADR では行わない（本番採用前に実施）。
@@ -67,3 +67,61 @@ ADR-0012 は廃止しない。本 ADR は ADR-0012 の「直接 API を却下」
 - **抽出精度**: 3枚とも主要項目を正確に抽出。インボイス登録番号（T+13桁）・税額・日付を含め妥当。登録番号や税額が無い交通費領収書では正しく `null` を返した。
 
 **手書きサンプル（追加実測・4枚）**: 手書きの領収書4枚でも `output_config.format` は問題なく通り（全て `stop_reason: end_turn`）、レイテンシー **6.4〜8.4 秒**・**約 $0.032〜0.034/枚**と印刷サンプルと同水準。**店名・手書きの日付・合計金額を正確に抽出**し、実用水準の読み取り精度を確認した。税額を別記しない領収書では税額を正しく `null`、"T+13桁" 形式でない登録番号（例: 8桁のみ）は正規化契約（`^T\d{13}$`）により正しく `null` とした。手書きを含む Document AI / Gemini との定量比較は本番採用判断時に拡充する。（※サンプルは個人情報を含むため本 ADR には具体内容を記録せず集計のみ）
+
+### Vertex 経路の再評価（実測・2026-08-14 / `claude-opus-4-8`）
+
+本 ADR 執筆時点の前提（Vertex 上の Claude クォータが全 base model で 0）が変化したため、`CLAUDE_TRANSPORT=vertex` の疎通を再確認した。結論として **クォータは付与されていたが、別要因により vertex 経路は現状のコードでは利用できない**。
+
+#### 1. クォータ・モデルアクセス
+
+最小トークンのテキストリクエスト（`max_tokens: 16`）で確認した。
+
+| リージョン | `claude-opus-4-8`         | `claude-opus-5` / `claude-sonnet-5` / `claude-haiku-4-5` |
+| ---------- | ------------------------- | -------------------------------------------------------- |
+| `global`   | **200 OK**（1.8 秒）      | 404（Publisher model 未有効化）                          |
+| `us-east5` | 429（RESOURCE_EXHAUSTED） | 404（同上）                                              |
+
+- `global` の `claude-opus-4-8` は**クォータ付与済み**。本 ADR の前提だった「全 base model で 0」は、**この組み合わせに限って解消**された。他モデルは 404（Model Garden 未有効化）であり、**404 はクォータの有無を示さない**ため、有効化後に 429 となる可能性は残る。
+- `us-east5` は `online_prediction_input_tokens_per_minute_per_base_model`（base model `anthropic-claude-opus-4-8`）で 429。**クォータはリージョンごとに別枠**であり、global と us-east5 は独立している。
+- 既定モデル以外は Model Garden 側で未有効化のため 404。モデルを変更する場合は先に有効化が必要。
+
+#### 2. 新たなブロッカー: 組織ポリシーによる構造化出力の拒否
+
+実装（`createClaudeReceiptExtractor`）をそのまま `CLAUDE_TRANSPORT=vertex` で実行すると、画像リクエストが **400 FAILED_PRECONDITION** で失敗する。
+
+```
+Organization Policy constraint constraints/vertexai.allowedPartnerModelFeatures violated
+... attempting to use a disallowed feature structured_outputs for Partner model claude-opus-4-8
+```
+
+- 原因は本 ADR で両トランスポート共通としていた**構造化出力 `output_config.format`**。
+- Vertex では `structured_outputs` は**組織配下のプロジェクトでは既定で拒否**され、組織ポリシー `constraints/vertexai.allowedPartnerModelFeatures` の許可値に `publishers/anthropic/models/claude-opus-4-8:structured_outputs` を追加する必要がある（モデルごとに 1 エントリ）。設定には `roles/orgpolicy.policyAdmin` が必要。
+- Anthropic 直接 API にはこの制約が無く、本 ADR の api 経路実測（前節）で問題なく通っていた。**同じ Messages API でもトランスポートによって利用可否が異なる**点が、本 ADR で想定していなかった差分である。
+
+#### 3. 代替方式の実測
+
+構造化出力を使わずに形式を確保できるかを検証した。
+
+| 方式                                           | 結果       | レイテンシー | 入力 / 出力トークン |
+| ---------------------------------------------- | ---------- | ------------ | ------------------- |
+| `output_config.format`（現行実装）             | **400**    | —            | —                   |
+| tool use + `tool_choice` 強制（`strict` なし） | **200 OK** | 8.3 秒       | 5,683 / 356         |
+| tool use + `strict: true`                      | **400**    | —            | —                   |
+| プロンプトで JSON 指示（構造化出力なし）       | 200 OK     | 7.1 秒       | 4,951 / 258         |
+
+- **`strict: true` も同じ `structured_outputs` フィーチャー扱いで拒否される**。一方、素の tool use は許可される。
+- **強制 tool use が最有力の代替**。`tool_use.input` がパース済みの JSON オブジェクトとして返るため、フェンス剥がしや `JSON.parse` 失敗が発生しない。実測でもスキーマの 6 キーが全て揃い、余計なキーは無かった。
+- プロンプトによる JSON 指示は ` ```json ` フェンス付きで返るため、剥がし処理とパース失敗時のリトライを自前で持つ必要があり、tool use より脆い。
+- `strict` によるスキーマ強制を失っても、`normalizeReceiptExtraction`（`packages/functions/src/application/receipt-normalize.ts`）が**キー欠損・型違いを境界で吸収**するため後段は壊れない。構造化出力は「あれば楽」だが、正準モデルへの正規化契約は既に独立して担保されている。
+- 200 で通った 2 方式はいずれも主要項目（店名・日付・合計金額・税額）を抽出し、記載の無い登録番号は `null` を返した。ただし**同一サンプルでの api 経路との値の突き合わせは未実施**であり、精度の同等性までは確認していない（※サンプルは個人情報を含むため具体内容は記録しない）。
+
+#### 4. 判断
+
+**Vertex 経路への切り替えは見送り、`CLAUDE_TRANSPORT=api` を既定のまま継続する。** 組織ポリシーの変更権限が無く、コード側での代替実装（強制 tool use への分岐）は本 ADR のスコープ外のため、本節は判断材料の記録に留める。
+
+vertex 経路を有効化する場合、以下のいずれかが必要になる。
+
+1. **組織ポリシーの許可値追加**（推奨・コード変更不要）: 管理者が `constraints/vertexai.allowedPartnerModelFeatures` に `publishers/anthropic/models/claude-opus-4-8:structured_outputs` を追加する。両トランスポートの実装差分をクライアント生成のみに保てる。
+2. **コード側での代替実装**: vertex 時のみ強制 tool use に分岐する。組織ポリシーに依存しないが、本 ADR の「共有ロジック＋クライアント生成の差分のみ」という設計方針を崩す範囲が**リクエスト組み立てに留まらない**点に注意する。強制 tool use では JSON が `tool_use` ブロックの `input` に入り text ブロックが返らないため、text ブロックを探して `JSON.parse` する現行のレスポンス解析（`packages/functions/src/infrastructure/claude-client.ts` の `messages.create` 後段）も分岐が必要になる。すなわちリクエスト・レスポンス双方の分岐となり、共有できるのはプロンプトとスキーマ定義、および `normalizeReceiptExtraction` への受け渡しに留まる。
+
+いずれも別 Issue / 別 ADR で扱う。

--- a/docs/adr/0013-direct-anthropic-api-transport.md
+++ b/docs/adr/0013-direct-anthropic-api-transport.md
@@ -43,7 +43,7 @@ ADR-0012 は廃止しない。本 ADR は ADR-0012 の「直接 API を却下」
 - **コスト**: 単価は Vertex と同水準（既定 `claude-opus-4-8` 入力 $5.00 / 出力 $25.00・100万トークンあたり）。従量課金は **Anthropic 側の請求**となり、GCP 請求とは別系統。1 枚あたり概算は ADR-0012 のコスト表を流用し、実測は本 ADR の検証で採取する。
 - **クォータ・レート制限**: Anthropic API の**アカウント単位のレート上限（RPM / ITPM / OTPM、利用 Tier に依存）**に従う。GCP クォータ非依存。件数増加時は Tier 引き上げ・バックオフ方針を評価する。
 - **レイテンシー**: `claude-opus-4-8` は高精度な一方、応答時間は Gemini Flash より長くなり得る（ADR-0012 と同様）。`CLAUDE_TIMEOUT_MS`（既定 30 秒）と Cloud Functions タイムアウト（gen2 既定 60 秒）の妥当性を検証で確認する。SDK の再試行（既定 maxRetries=2 でタイムアウトも再試行）は Vertex 実装同様に無効化し、関数の外側デッドライン超過とコスト増を避ける。
-- **データレジデンシー・個人情報（最重要トレードオフ）**: 領収書には店名・日付・金額・登録番号など個人情報・取引情報が含まれる。直接 API では、これらが **GCP / Vertex を経由せず Anthropic の API（主に米国リージョン）へ送信**される。Anthropic API は既定で**入力データをモデル学習に使用せず**、一定期間で削除する運用だが、**GCP 内に処理が閉じる Vertex 経路とは処理主体・データ処理条件（DPA）が異なる**。本 ADR では **評価 / POC 目的に限り許容**とする。**本番採用の前に、Anthropic のデータ処理条件・DPA の確認、個人情報保護法・契約上の要件充足、必要に応じ ZDR（ゼロデータ保持）等のオプション要否を検討する**ことを必須とする。データ所在要件が厳しい場合は `CLAUDE_TRANSPORT=vertex` を選ぶ。ただし後述の「Vertex 経路の再評価」の通り、この用途では **3 条件**が必要になる（2026-08-14 時点でいずれも未充足）。(1) `global` は処理リージョンを保証しないため `CLAUDE_LOCATION` にマルチリージョン／リージョン指定が必要（ADR-0012）、(2) **そのリージョンでのクォータ付与**（実測では `us-east5` は 429。クォータはリージョンごとに別枠）、(3) 組織ポリシーによる構造化出力の許可、またはコード側での代替実装。
+- **データレジデンシー・個人情報（最重要トレードオフ）**: 領収書には店名・日付・金額・登録番号など個人情報・取引情報が含まれる。直接 API では、これらが **GCP / Vertex を経由せず Anthropic の API（主に米国リージョン）へ送信**される。Anthropic API は既定で**入力データをモデル学習に使用せず**、一定期間で削除する運用だが、**GCP 内に処理が閉じる Vertex 経路とは処理主体・データ処理条件（DPA）が異なる**。本 ADR では **評価 / POC 目的に限り許容**とする。**本番採用の前に、Anthropic のデータ処理条件・DPA の確認、個人情報保護法・契約上の要件充足、必要に応じ ZDR（ゼロデータ保持）等のオプション要否を検討する**ことを必須とする。データ所在要件が厳しい場合は `CLAUDE_TRANSPORT=vertex` を選ぶ。ただし後述の「Vertex 経路の再評価」の通り、この用途では **3 条件**が必要になる（2026-08-14 時点で (2)(3) が未充足。付与済みの `global` のクォータは、処理リージョンを保証しないためこの用途には使えない）。(1) `global` は処理リージョンを保証しないため `CLAUDE_LOCATION` にマルチリージョン／リージョン指定が必要（ADR-0012）、(2) **そのリージョンでのクォータ付与**（実測では `us-east5` は 429。クォータはリージョンごとに別枠）、(3) 組織ポリシーによる構造化出力の許可、またはコード側での代替実装。
 - **コンプライアンス・セキュリティ**: 新シークレット `ANTHROPIC_API_KEY` を **Secret Manager** で管理する（コードにハードコードしない。ローカルは `.env.local`、デプロイ環境は Functions ランタイムのサービスアカウントに Secret アクセス権を付与）。キー漏洩時のローテーション手順を運用に含める。`onRequest` の呼び出し側認証は既存 `API_KEY` を流用する。Vertex 経路と異なり `roles/aiplatform.user` は不要。
 - **受容リスク（本 ADR のスコープであえて対応しないと決めた事項）**:
   - Anthropic のデータ処理条件の詳細確認・DPA 締結は本 ADR では行わない（本番採用前に実施）。
@@ -89,7 +89,7 @@ ADR-0012 は廃止しない。本 ADR は ADR-0012 の「直接 API を却下」
 
 実装（`createClaudeReceiptExtractor`）をそのまま `CLAUDE_TRANSPORT=vertex` で実行すると、画像リクエストが **400 FAILED_PRECONDITION** で失敗する。
 
-```
+```text
 Organization Policy constraint constraints/vertexai.allowedPartnerModelFeatures violated
 ... attempting to use a disallowed feature structured_outputs for Partner model claude-opus-4-8
 ```

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -145,6 +145,8 @@ Firebase Functions は[環境構成ファイル](https://firebase.google.com/doc
 - `CLAUDE_TRANSPORT=api`（既定）: Anthropic 直接 API。`ANTHROPIC_API_KEY` を使用。
 - `CLAUDE_TRANSPORT=vertex`: Vertex AI 経由（ADC 認証）。`ANTHROPIC_API_KEY` は未使用。
 
+> **注意（2026-08-14 時点）**: `vertex` は本プロジェクトの GCP 環境では**利用できません**。組織のポリシー制約 `constraints/vertexai.allowedPartnerModelFeatures` により構造化出力（`output_config.format`）が拒否され、抽出リクエストが全て `400 FAILED_PRECONDITION` になります（組織配下のプロジェクトでは既定で拒否されます）。有効化に必要な条件は ADR-0013「Vertex 経路の再評価」を参照してください。
+
 - **ローカル開発**: api 経路を試す場合、`.env.local` に `ANTHROPIC_API_KEY=<値>` を設定（エミュレータが読み込む）。
 - **デプロイ環境**: Google Cloud Secret Manager で管理（後述）。
 


### PR DESCRIPTION
# 概要

Vertex AI 経由 Claude の疎通を再確認した結果、ADR-0013 の前提が変化していたため、実測結果を ADR-0013 に追記する。コード変更はなし。

## 種別

- [ ] bug
- [ ] feature
- [ ] refactor
- [ ] chore
- [x] docs
- [ ] test

---

# 変更内容（What）

ドキュメント 3 ファイル（+66 / -6）。

**`docs/adr/0013-direct-anthropic-api-transport.md`**

- 「Vertex 経路の再評価（実測・2026-08-14 / `claude-opus-4-8`）」節を追加
  - クォータ・モデルアクセスの実測（`global` / `us-east5` × 4 モデル）
  - 組織ポリシー `constraints/vertexai.allowedPartnerModelFeatures` による 400 FAILED_PRECONDITION と、必要な許可値
  - 代替方式の実測（強制 tool use / プロンプト JSON 指示 / `strict: true`）
  - 判断（Vertex 経路は見送り、`CLAUDE_TRANSPORT=api` を既定のまま継続）と、有効化する場合の 2 つの選択肢
- 既存の「クォータ付与後は `CLAUDE_TRANSPORT=vertex` に戻せる」旨の記述 4 箇所に、復帰条件を注記
- コンテキスト冒頭に「本 ADR 執筆時点の状況であり後日変化した」旨を注記

既存の決定・理由そのものは書き換えず、条件の追記に留めている（ADR の意思決定を後から改変しないため）。

**`README.md` / `packages/functions/README.md`**

- `CLAUDE_TRANSPORT=vertex` を利用可能な選択肢として説明したままだったため、現状は組織ポリシーにより利用できない旨の警告を追記（README どおりに設定すると全リクエストが 400 になるため）

---

# 変更理由（Why）

ADR-0013 は「Vertex 上の Claude クォータが全 base model で 0」を前提に、Anthropic 直接 API を既定としていた。今回の実測でこの前提が変化し、かつ記述と実態が乖離していたため。

- クォータは `global` × `claude-opus-4-8` に**付与済み**だった（前提の解消）
- 一方で組織ポリシーにより構造化出力（`output_config.format`）が拒否され、**現状のコードでは vertex 経路が動かない**（新たなブロッカー）
- そのため「クォータ付与後は設定変更だけで戻せる」という記述が不正確になっていた

組織ポリシーの変更権限が無いため Vertex 対応自体は見送り、次に判断する人が同じ調査を繰り返さずに済むよう、実測結果と復帰条件を記録する。

---

# 影響範囲（Impact）

- Backend: なし（ドキュメントのみ。コード・設定・依存の変更なし）
- Infra: なし（`CLAUDE_TRANSPORT` の既定値 `api` は変更していない）

運用面では、README を見て `CLAUDE_TRANSPORT=vertex` を設定しようとしていた場合に、事前に利用不可と分かるようになる。

---

# 動作確認

## 確認観点

- [ ] 正常系
- [ ] 異常系
- [ ] 境界値
- [x] 回帰影響なし

ドキュメントのみの変更のため、実行時の正常系・異常系・境界値は対象外。記載した実測値そのものは以下の手順で採取した。

## 確認手順

1. 使い捨てスクリプトを `packages/functions/` に置き、Docker 経由で `CLAUDE_TRANSPORT=vertex` の疎通を確認する（`docker-compose -f packages/functions/docker/docker-compose.yml run --rm -w /app/packages/functions functions node <script>.mjs`）
2. 最小トークンのテキストリクエストで `global` / `us-east5` × `claude-opus-4-8` / `claude-opus-5` / `claude-sonnet-5` / `claude-haiku-4-5` のクォータ・モデルアクセスを確認する
3. `createClaudeReceiptExtractor` をそのまま実行し、400 FAILED_PRECONDITION（組織ポリシー違反）を確認する
4. 構造化出力を外した呼び出し・強制 tool use（`strict` あり / なし）を実行し、可否とレイテンシー・トークン数を採取する
5. 採取後にスクリプトを削除する（作業ツリーに残さない）

---

# テスト

- [ ] 単体テスト追加／更新
- [ ] 統合テスト追加／更新
- [x] 既存テスト通過

ドキュメントのみの変更でテスト対象コードに触れていないため、テストの追加・更新はなし。

---

# リスク・懸念点

- 記載した実測値は 2026-08-14 時点・GCP プロジェクト `documentaisample-488504` のもの。クォータ付与状況と組織ポリシーはいずれも外部要因で変わりうるため、vertex 経路を実際に使う際は再確認が必要。
- 実測に使ったサンプルは個人情報を含むため、ADR には可否と数値のみを記録し具体内容は残していない（ADR-0010 / PR #225 と同方針）。
- 代替方式（強制 tool use）は実測で有効性を確認したが、本 PR では採用しておらず実装もしていない。採用する場合は**リクエスト組み立てとレスポンス解析の双方**が分岐する（現行実装は text ブロックを前提に `JSON.parse` しており、tool use では必ず失敗する）ため、別 Issue / 別 ADR で扱う。
- 表に記載した抽出結果は項目の有無のみの確認であり、同一サンプルでの api 経路との値の突き合わせは未実施。精度の同等性までは主張していない。

## `/code-review` の反映

PR 作成前に `/code-review` を 1 回実施し、7 件の指摘のうち 6 件を反映済み（残り 1 件は本 PR のスコープ外として別 Issue 化）。主な修正は以下。

- 「全 base model で 0 は解消された」という記述が測定より強かったため、`global` × `claude-opus-4-8` 限定に修正（404 はクォータの有無を示さない）
- 代替実装の影響範囲がリクエスト組み立てのみと読める記述を、レスポンス解析も分岐が必要と修正
- データ所在要件での vertex 利用に必要な条件を 3 つ（リージョン指定 / 当該リージョンのクォータ / ポリシー許可）に明記
- README 2 ファイルへの警告追記（上記「変更内容」参照）

---

# 関連 Issue

Closes #245
Refs #227

---

# チェックリスト（レビュー前セルフチェック）

### 基本

- [x] Conventional Commits に準拠
- [x] 不要なログを削除（検証用スクリプトは採取後に削除済み）
- [x] any 型を増やしていない（コード変更なし）
- [x] 80行超の関数を作っていない（コード変更なし）
- [x] 200行超のファイルを作っていない
- [x] 影響範囲を確認済み

### セキュリティ

- [x] ユーザー入力のバリデーションを実装している（コード変更なし）
- [x] シークレットや API キーをハードコードしていない
- [x] 領収書の個人情報（店名・登録番号等）を記載していない

### エラーハンドリング

- [x] 外部 API 呼び出しに適切なエラーハンドリングがある（コード変更なし）
- [x] ファイル I/O に適切なエラーハンドリングがある（コード変更なし）

### 設計

- [x] レイヤー違反がない（コード変更なし）
- [x] 既存パターンとの一貫性を保っている（既存 ADR の検証結果節と同じ構成で追記）

### 変更範囲

- [x] PR が1つの目的に絞られている
- [x] 不要な依存パッケージを追加していない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Claude を Vertex 経由で利用する際、構造化出力が組織ポリシーにより拒否され、現行の GCP 環境では利用できない旨を追記しました。
  * 既定の直接 Anthropic API は引き続き利用します。
  * Vertex 経路の再導入に必要なクォータ、権限、代替実装の条件と検証結果を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->